### PR TITLE
chore: handle when hardware does not support Vulkan video

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -75,7 +75,7 @@
         },
         .vulkan_zig = .{
             .url = "https://github.com/Snektron/vulkan-zig/archive/zig-0.15-compat.tar.gz",
-            .hash = "vulkan-0.0.0-r7Ytx6hBAwBUnt0XA-uOkR2hda4fAHFhQITNTgJpnFkY",
+            .hash = "vulkan-0.0.0-r7Ytx_VDAwAiMl0YSu2UOkVMIGJN7CeIQaxJR-hUSfD6",
         },
         .imguiz = .{
             .url = "git+https://github.com/mgerb/imguiz#7d6e1a4dfb2f31da24c9f76e0c4ba8285e89d289",
@@ -87,11 +87,11 @@
         },
         .ffmpeg_linux = .{
             .url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-linux64-gpl-shared-7.1.tar.xz",
-            .hash = "N-V-__8AANQu9gvRFBkaaFdsPBJ0O0P4i6uctG8P4vczdjEK",
+            .hash = "N-V-__8AAMVhFwyEn-loOh3RvLuNHFbK-_cUx6F781wmKELD",
         },
         .ffmpeg_windows = .{
             .url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.1-latest-win64-gpl-shared-7.1.zip",
-            .hash = "N-V-__8AALCxywofrbiZJX6duwGaBapY7KZ8mphf_0Dbt7Lg",
+            .hash = "N-V-__8AAJk_Dgsw1bGPOwZaDiVZlSS6gFZfdqjg2ObF4vOu",
         },
         .libportal = .{
             .url = "https://github.com/flatpak/libportal/archive/refs/tags/0.9.1.tar.gz",

--- a/src/state.zig
+++ b/src/state.zig
@@ -21,9 +21,13 @@ recording: bool = false,
 has_source: bool = false,
 show_demo: bool = false,
 selected_screen_cast_identifier: ?[]u8 = null,
+is_video_capture_supprted: bool,
 
 replay_buffer_state: ReplayBufferState = .{},
 
-pub fn init(user_settings: UserSettings) Self {
-    return .{ .user_settings = user_settings };
+pub fn init(user_settings: UserSettings, is_video_capture_supprted: bool) Self {
+    return .{
+        .user_settings = user_settings,
+        .is_video_capture_supprted = is_video_capture_supprted,
+    };
 }

--- a/src/ui/draw_left_column.zig
+++ b/src/ui/draw_left_column.zig
@@ -3,18 +3,17 @@ const c = @import("imguiz").imguiz;
 const StateActor = @import("../state_actor.zig").StateActor;
 const imgui_util = @import("./imgui_util.zig");
 
+pub const COLUMN_WIDTH = 250;
+
 pub fn drawLeftColumn(allocator: std.mem.Allocator, state_actor: *StateActor) !void {
     // Get viewport size
     const viewport_pos = c.ImGui_GetMainViewport().*.Pos;
     const viewport_size = c.ImGui_GetMainViewport().*.Size;
 
-    // Define left panel size
-    const left_panel_width = 250.0;
-
     // Set position and size for the left panel window
     c.ImGui_SetNextWindowPos(viewport_pos, 0);
     c.ImGui_SetNextWindowSize(c.ImVec2{
-        .x = left_panel_width,
+        .x = COLUMN_WIDTH,
         .y = viewport_size.y,
     }, 0);
 
@@ -32,7 +31,9 @@ pub fn drawLeftColumn(allocator: std.mem.Allocator, state_actor: *StateActor) !v
         if (c.ImGui_BeginTabItem("Capture", null, 0)) {
             defer c.ImGui_EndTabItem();
 
+            const video_capture_supported = state_actor.state.is_video_capture_supprted;
             if (c.ImGui_BeginTable("source_table", 2, c.ImGuiTableFlags_None)) {
+                c.ImGui_BeginDisabled(!video_capture_supported);
                 _ = c.ImGui_TableNextColumn();
                 if (c.ImGui_ButtonEx("Desktop", .{ .x = c.ImGui_GetContentRegionAvail().x, .y = 0 })) {
                     try state_actor.dispatch(.{ .select_video_source = .desktop });
@@ -42,6 +43,7 @@ pub fn drawLeftColumn(allocator: std.mem.Allocator, state_actor: *StateActor) !v
                 if (c.ImGui_ButtonEx("Window", .{ .x = c.ImGui_GetContentRegionAvail().x, .y = 0 })) {
                     try state_actor.dispatch(.{ .select_video_source = .window });
                 }
+                c.ImGui_EndDisabled();
                 c.ImGui_EndTable();
             }
 
@@ -61,7 +63,7 @@ pub fn drawLeftColumn(allocator: std.mem.Allocator, state_actor: *StateActor) !v
                 c.ImGui_PushStyleColorImVec4(c.ImGuiCol_Button, c.ImVec4{ .x = 0.251, .y = 0.627, .z = 0.169, .w = 1.0 });
                 c.ImGui_PushStyleColorImVec4(c.ImGuiCol_ButtonHovered, c.ImVec4{ .x = 0.329, .y = 0.706, .z = 0.247, .w = 1.0 });
                 c.ImGui_PushStyleColorImVec4(c.ImGuiCol_ButtonActive, c.ImVec4{ .x = 0.173, .y = 0.471, .z = 0.129, .w = 1.0 });
-                c.ImGui_BeginDisabled(state_actor.state.recording or !state_actor.state.has_source);
+                c.ImGui_BeginDisabled(!video_capture_supported or state_actor.state.recording or !state_actor.state.has_source);
                 if (c.ImGui_ButtonEx("Start", .{ .x = -std.math.floatMin(f32), .y = 0 })) {
                     try state_actor.dispatch(.start_record);
                 }
@@ -73,7 +75,7 @@ pub fn drawLeftColumn(allocator: std.mem.Allocator, state_actor: *StateActor) !v
                 c.ImGui_PushStyleColorImVec4(c.ImGuiCol_Button, c.ImVec4{ .x = 0.6, .y = 0.0, .z = 0.0, .w = 1.0 });
                 c.ImGui_PushStyleColorImVec4(c.ImGuiCol_ButtonHovered, c.ImVec4{ .x = 0.75, .y = 0.1, .z = 0.1, .w = 1.0 });
                 c.ImGui_PushStyleColorImVec4(c.ImGuiCol_ButtonActive, c.ImVec4{ .x = 0.5, .y = 0.0, .z = 0.0, .w = 1.0 });
-                c.ImGui_BeginDisabled(!state_actor.state.recording);
+                c.ImGui_BeginDisabled(!video_capture_supported or !state_actor.state.recording);
                 if (c.ImGui_ButtonEx("Stop", .{ .x = -std.math.floatMin(f32), .y = 0 })) {
                     try state_actor.dispatch(.stop_record);
                 }
@@ -94,7 +96,7 @@ pub fn drawLeftColumn(allocator: std.mem.Allocator, state_actor: *StateActor) !v
             c.ImGui_PushStyleColorImVec4(c.ImGuiCol_Button, c.ImVec4{ .x = 0.447, .y = 0.529, .z = 0.992, .w = 1.0 });
             c.ImGui_PushStyleColorImVec4(c.ImGuiCol_ButtonHovered, c.ImVec4{ .x = 0.525, .y = 0.608, .z = 1.000, .w = 1.0 });
             c.ImGui_PushStyleColorImVec4(c.ImGuiCol_ButtonActive, c.ImVec4{ .x = 0.369, .y = 0.451, .z = 0.874, .w = 1.0 });
-            c.ImGui_BeginDisabled(!state_actor.state.recording);
+            c.ImGui_BeginDisabled(!video_capture_supported or !state_actor.state.recording);
             if (c.ImGui_ButtonEx("Save Replay", .{ .x = c.ImGui_GetContentRegionAvail().x, .y = 30 })) {
                 try state_actor.dispatch(.save_replay);
             }

--- a/src/ui/draw_video_preview.zig
+++ b/src/ui/draw_video_preview.zig
@@ -1,13 +1,20 @@
 const c = @import("imguiz").imguiz;
 const VulkanImageBuffer = @import("../vulkan/vulkan_image_buffer.zig").VulkanImageBuffer;
 const CapturePreviewTexture = @import("../vulkan/capture_preview_texture.zig").CapturePreviewTexture;
+const COLUMN_WIDTH = @import("./draw_left_column.zig").COLUMN_WIDTH;
 
-pub fn drawVideoPreview(capture_preview_buffer: *CapturePreviewTexture, width: u32, height: u32) !void {
-    const left_panel_width = 250.0;
+pub fn drawVideoPreview(args: union(enum) {
+    vulkan_video_not_supported,
+    capture_preview: struct {
+        capture_preview_buffer: *CapturePreviewTexture,
+        width: u32,
+        height: u32,
+    },
+}) !void {
     const viewport_size = c.ImGui_GetMainViewport().*.Size;
-    const container_width = viewport_size.x - left_panel_width;
-    const container_height = viewport_size.y;
-    c.ImGui_SetNextWindowPos(.{ .x = left_panel_width, .y = 0 }, 0);
+    const container_width = viewport_size.x - COLUMN_WIDTH;
+    const container_height = viewport_size.y * 0.7;
+    c.ImGui_SetNextWindowPos(.{ .x = COLUMN_WIDTH, .y = 0 }, 0);
     c.ImGui_SetNextWindowSize(c.ImVec2{
         .x = container_width,
         .y = container_height,
@@ -28,25 +35,37 @@ pub fn drawVideoPreview(capture_preview_buffer: *CapturePreviewTexture, width: u
     defer c.ImGui_PopStyleVarEx(2);
     defer c.ImGui_End();
 
-    const capture_width = @as(f32, @floatFromInt(width));
-    const capture_height = @as(f32, @floatFromInt(height));
+    if (args == .capture_preview) {
+        const capture_width = @as(f32, @floatFromInt(args.capture_preview.width));
+        const capture_height = @as(f32, @floatFromInt(args.capture_preview.height));
 
-    const aspect_ratio = capture_width / capture_height;
+        const aspect_ratio = capture_width / capture_height;
 
-    var render_width = container_width;
-    var render_height = render_width / aspect_ratio;
+        var render_width = container_width;
+        var render_height = render_width / aspect_ratio;
 
-    if (render_height > container_height) {
-        render_height = container_height;
-        render_width = render_height * aspect_ratio;
+        if (render_height > container_height) {
+            render_height = container_height;
+            render_width = render_height * aspect_ratio;
+        }
+
+        if (render_width > container_width) {
+            render_width = container_width;
+            render_height = render_width / aspect_ratio;
+        }
+
+        const cursor_x = (container_width - render_width) / 2;
+        c.ImGui_SetCursorPosX(cursor_x);
+        c.ImGui_Image(args.capture_preview.capture_preview_buffer.im_texture_ref, .{ .x = render_width, .y = render_height });
+    } else {
+        const message = "Vulkan video is not supported on your current hardware. Video recording will be disabled.";
+        const wrap_width = container_width * 0.8;
+        const text_size = c.ImGui_CalcTextSizeEx(message, null, false, wrap_width);
+        const cursor_x = (container_width - text_size.x) / 2;
+        const cursor_y = (container_height - text_size.y) / 2;
+        c.ImGui_SetCursorPos(.{ .x = cursor_x, .y = cursor_y });
+        c.ImGui_PushTextWrapPos(cursor_x + wrap_width);
+        c.ImGui_TextWrapped(message);
+        c.ImGui_PopTextWrapPos();
     }
-
-    if (render_width > container_width) {
-        render_width = container_width;
-        render_height = render_width / aspect_ratio;
-    }
-
-    const cursor_x = (container_width - render_width) / 2;
-    c.ImGui_SetCursorPosX(cursor_x);
-    c.ImGui_Image(capture_preview_buffer.im_texture_ref, .{ .x = render_width, .y = render_height });
 }

--- a/src/ui/ui.zig
+++ b/src/ui/ui.zig
@@ -8,6 +8,7 @@ const Vulkan = @import("../vulkan/vulkan.zig").Vulkan;
 const API_VERSION = @import("../vulkan/vulkan.zig").API_VERSION;
 const drawLeftColumn = @import("./draw_left_column.zig").drawLeftColumn;
 const drawVideoPreview = @import("./draw_video_preview.zig").drawVideoPreview;
+const drawVideoPreviewUnavailable = @import("./draw_video_preview.zig").drawVideoPreviewUnavailable;
 const VulkanImageBuffer = @import("../vulkan/vulkan_image_buffer.zig").VulkanImageBuffer;
 
 // TODO: save and restore window size
@@ -346,12 +347,18 @@ pub const UI = struct {
 
                 try drawLeftColumn(self.allocator, self.state_actor);
 
-                if (self.state_actor.state.recording) {
+                if (!self.state_actor.state.is_video_capture_supprted) {
+                    try drawVideoPreview(.vulkan_video_not_supported);
+                } else if (self.state_actor.state.recording) {
                     if (self.vulkan.capture_preview_ring_buffer) |capture_preview_ring_buffer| {
                         if (capture_preview_ring_buffer.getMostRecentBuffer()) |buffer| {
                             capture_preview_buffer = buffer;
                             const capture_preview_texture = try self.vulkan.getCapturePreviewTexture(buffer);
-                            try drawVideoPreview(capture_preview_texture, buffer.width, buffer.height);
+                            try drawVideoPreview(.{ .capture_preview = .{
+                                .capture_preview_buffer = capture_preview_texture,
+                                .width = buffer.width,
+                                .height = buffer.height,
+                            } });
                         }
                     }
                 }


### PR DESCRIPTION
- Don't try to configure video encode queue.
- Show message on the UI indicating Vulkan video is not supported.
- Disable source buttons.