### PR TITLE
build: fix windows build

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -259,7 +259,7 @@ fn buildWindows(
         .b = b,
         .exe = exe,
         .source_dir = ffmpeg_path,
-        .lib_name = "avformat-61",
+        .lib_name = "avformat-62",
         .target = .windows,
     });
     try installAndLinkSystemLibrary(.{
@@ -267,7 +267,7 @@ fn buildWindows(
         .b = b,
         .exe = exe,
         .source_dir = ffmpeg_path,
-        .lib_name = "avcodec-61",
+        .lib_name = "avcodec-62",
         .target = .windows,
     });
     try installAndLinkSystemLibrary(.{
@@ -275,7 +275,7 @@ fn buildWindows(
         .b = b,
         .exe = exe,
         .source_dir = ffmpeg_path,
-        .lib_name = "avdevice-61",
+        .lib_name = "avdevice-62",
         .target = .windows,
     });
     try installAndLinkSystemLibrary(.{
@@ -283,7 +283,7 @@ fn buildWindows(
         .b = b,
         .exe = exe,
         .source_dir = ffmpeg_path,
-        .lib_name = "avfilter-10",
+        .lib_name = "avfilter-11",
         .target = .windows,
     });
     try installAndLinkSystemLibrary(.{
@@ -291,7 +291,7 @@ fn buildWindows(
         .b = b,
         .exe = exe,
         .source_dir = ffmpeg_path,
-        .lib_name = "avutil-59",
+        .lib_name = "avutil-60",
         .target = .windows,
     });
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -87,8 +87,8 @@
             .hash = "N-V-__8AAH4RHQXHEafp_hkUel3EMeK1wjHBfaIYYxYsKdiM",
         },
         .ffmpeg_windows = .{
-            .url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-02-10-13-08/ffmpeg-n7.1.3-40-gcddd06f3b9-win64-gpl-shared-7.1.zip",
-            .hash = "N-V-__8AAJl9FQsCnNsH8YA5Qbdo9lCRXd8h-ZU9O0Uq5BH7",
+            .url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n8.0-latest-win64-gpl-shared-8.0.zip",
+            .hash = "N-V-__8AALVsYQ-fnCQXlE_7IJy8hmcgOsDDswPqy89TDLCw",
         },
         .libportal = .{
             .url = "https://github.com/flatpak/libportal/archive/refs/tags/0.9.1.tar.gz",


### PR DESCRIPTION
Eventually will need to compile static ffmpeg libraries for windows. The prebuilt binaries currently in the dependencies are eventually removed so the build is going to break every few weeks.