### PR TITLE
feat: IPC server for global shortcuts on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,82 +3,55 @@
 A hardware accelerated replay capture tool focused on performance. Currently
 only supports Linux.
 
-This is currently in the very early stages of development.
+![screenshot2](./screenshots/screenshot_3.png)
+
+<p align="center">(very early screenshot - UI still in development)</p>
 
 - Written in [Zig](https://ziglang.org/).
 - Hardware accelerated encoding with Vulkan Video ([vulkan-zig](https://github.com/Snektron/vulkan-zig)).
 - UI built with [imgui](https://github.com/ocornut/imgui)/[SDL3](https://github.com/allyourcodebase/SDL3).
 
+## Features
+
+- Desktop/window capture
+- Save last n seconds of video
+- Global keybinds
+
 ## Why you might want to use this?
 
-You play games on Linux and are looking for a light weight and performant
+You play games on Linux and are looking for a lightweight and performant
 alternative to OBS for capturing video replays.
 
-## What currently is working?
+## Requirements
 
-- Linux
-  - Select desktop/window.
-  - Video capture preview on UI.
-  - Replay buffer with last n seconds of video/audio.
-  - Output to .mp4 file.
-  - Global keybinds via desktop portal.
-- Windows
-  - Binaries are built for Windows, but capture has not been implemented yet.
+- GPU that supports Vulkan Video
 
-**NOTE:** I'm testing with an RTX 3080 GPU. I have no idea if AMD works. I don't have one to test on.
+### Linux
 
-## Linux Requirements
-
-- vulkan (and related graphics drivers)
+- vulkan
 - pipewire
 - pipewire-pulse
 
-### Installation
+#### Global Keybinds
 
-**NOTE:** A reboot may be required.
+If your version of Linux supports [xdg-desktop-portal global shortcuts](https://wiki.archlinux.org/title/XDG_Desktop_Portal#List_of_backends_and_interfaces) then you can configure it that way.
+Otherwise, the Spacecap CLI can be used to send commands to the IPC server.
 
-#### NixOS
+For example, here is what a config in [niri](https://github.com/YaLTeR/niri) would look like:
 
-There is currently not a Nix package published, but for now you can use
-`appimage-run` to execute the appimage.
-
-TODO: Add vulkan instructions.
-
-```nix
-{...}: {
-  security.rtkit.enable = true;
-
-  services.pipewire = {
-    enable = true;
-    alsa.enable = false;
-    pulse.enable = true;
-    wireplumber.enable = true;
-  };
-
-  environment.systemPackages = with pkgs; [
-    appimage-run
-  ];
+```kdl
+binds {
+    Mod+Shift+R hotkey-overlay-title="Spacecap: save replay" { spawn-sh "spacecap -s save-replay && notify-send 'Spacecap' 'Replay saved'"; }
 }
 ```
 
-#### Arch
+Use `spacecap -h` to see available commands.
 
-TODO: Add vulkan instructions.
+### Windows
 
-```sh
-sudo pacman -S --needed wireplumber pipewire pipewire-pulse pipewire-alsa fuse3
-systemctl --user --now enable pipewire pipewire-pulse wireplumber
-```
-
-#### Ubuntu
-
-TODO: Add vulkan instructions.
-
-```sh
-sudo apt update
-sudo apt install wireplumber pipewire pipewire-pulse pipewire-alsa fuse3
-systemctl --user --now enable pipewire pipewire-pulse wireplumber
-```
+Windows is not yet supported. This application was architected in such a way
+that it can be cross platform. For Windows support, the audio/video capture
+interfaces need to be implemented.
 
 ## Development
 
@@ -97,13 +70,9 @@ nix develop -c zig build run -Dnix
 nix develop -c zig build test -Dnix
 ```
 
-## Early Screenshot
-
-![screenshot2](./screenshots/screenshot_3.png)
-
 ## Roadmap
 
-- Set up pipeline to build and distribute binaries (appimage).
+- ~~Set up pipeline to build and distribute binaries (appimage).~~
 - ~~Audio recording.~~
 - ~~Global keybinds~~
 - Screenshots.

--- a/build.zig
+++ b/build.zig
@@ -66,6 +66,13 @@ fn addSharedDependencies(
     const zigrc = b.dependency("zigrc", .{});
     exe.root_module.addImport("zigrc", zigrc.module("zigrc"));
 
+    // zig-clap
+    const clap = b.dependency("clap", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("clap");
+    exe.root_module.addImport("clap", clap);
+
     const ffmpeg_build = switch (target.result.os.tag) {
         .windows => ffmpeg_build_util.build_windows(b),
         else => ffmpeg_build_util.build_linux(b),

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -106,6 +106,10 @@
             .url = "git+https://github.com/mgerb/pipewire#4f0f337aca61b127d0c7f800110b8513fbe85dd5",
             .hash = "pipewire-1.5.81-tKslQ3HyEgAxlVc9B_fwqHtJBsNMrQxQ1zQYZ_vMlBUt",
         },
+        .clap = .{
+            .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.11.0.tar.gz",
+            .hash = "clap-0.11.0-oBajB-HnAQDPCKYzwF7rO3qDFwRcD39Q0DALlTSz5H7e",
+        },
     },
 
     // Specifies the set of files and directories that are included in this package.

--- a/src/args.zig
+++ b/src/args.zig
@@ -1,0 +1,83 @@
+const std = @import("std");
+const clap = @import("clap");
+const Util = @import("./util.zig");
+
+const log = std.log.scoped(.cli_args);
+
+/// Params for all platforms should go here. Platform specific args should be added below.
+const shared_params =
+    "-h, --help             Display this help and exit.\n";
+
+const linux_params =
+    "-s, --send <command>   Send a command to a running Spacecap instance. Commands: save-replay\n";
+
+const windows_params =
+    "";
+
+const linux_params_parsed = clap.parseParamsComptime(shared_params ++ linux_params);
+const windows_params_parsed = clap.parseParamsComptime(shared_params ++ windows_params);
+
+pub const SendCommand = enum {
+    @"save-replay",
+};
+
+pub const Args = if (Util.isLinux())
+    union(enum) {
+        /// Send a command to the IPC server.
+        send: SendCommand,
+    }
+else
+    struct {};
+
+pub fn parse(allocator: std.mem.Allocator) ?Args {
+    if (comptime Util.isLinux()) {
+        return parseLinux(allocator);
+    } else if (comptime Util.isWindows()) {
+        return parseWindows(allocator);
+    } else {
+        log.err("unsupported platform", .{});
+        unreachable;
+    }
+}
+
+fn parseLinux(allocator: std.mem.Allocator) ?Args {
+    const parsers = comptime .{
+        .command = clap.parsers.enumeration(SendCommand),
+    };
+
+    var res = clap.parse(clap.Help, &linux_params_parsed, parsers, .{
+        .allocator = allocator,
+    }) catch |err| {
+        log.err("Unable to parse args: {}", .{err});
+        clap.helpToFile(.stderr(), clap.Help, &linux_params_parsed, .{}) catch {};
+        std.process.exit(1);
+    };
+    defer res.deinit();
+
+    if (res.args.help > 0) {
+        clap.helpToFile(.stderr(), clap.Help, &linux_params_parsed, .{}) catch {};
+        std.process.exit(0);
+    }
+
+    if (res.args.send) |cmd| return .{ .send = cmd };
+
+    return null;
+}
+
+fn parseWindows(allocator: std.mem.Allocator) ?Args {
+    var res = clap.parse(clap.Help, &windows_params_parsed, comptime .{}, .{
+        .allocator = allocator,
+    }) catch |err| {
+        log.err("Unable to parse args: {}", .{err});
+        clap.helpToFile(.stderr(), clap.Help, &windows_params_parsed, .{}) catch {};
+        std.process.exit(1);
+    };
+    defer res.deinit();
+
+    if (res.args.help > 0) {
+        clap.helpToFile(.stderr(), clap.Help, &windows_params_parsed, .{}) catch {};
+        std.process.exit(0);
+    }
+
+    return null;
+}

--- a/src/ipc/ipc.zig
+++ b/src/ipc/ipc.zig
@@ -1,0 +1,32 @@
+const std = @import("std");
+
+pub const IpcCommand = enum {
+    save_replay,
+};
+
+/// IPC interface.
+pub const Ipc = struct {
+    const Self = @This();
+
+    ptr: *anyopaque,
+    vtable: *const VTable,
+
+    const VTable = struct {
+        start: *const fn (*anyopaque) anyerror!void,
+        sendCommand: *const fn (*anyopaque, IpcCommand) anyerror!void,
+        deinit: *const fn (*anyopaque) void,
+    };
+
+    /// e.g. start an IPC server.
+    pub fn start(self: *Self) !void {
+        return self.vtable.start(self.ptr);
+    }
+
+    pub fn sendCommand(self: *Self, command: IpcCommand) !void {
+        return self.vtable.sendCommand(self.ptr, command);
+    }
+
+    pub fn deinit(self: *Self) void {
+        return self.vtable.deinit(self.ptr);
+    }
+};

--- a/src/ipc/linux/linux_ipc.zig
+++ b/src/ipc/linux/linux_ipc.zig
@@ -1,0 +1,67 @@
+const std = @import("std");
+const StateActor = @import("../../state_actor.zig").StateActor;
+const Ipc = @import("../ipc.zig").Ipc;
+const IpcCommand = @import("../ipc.zig").IpcCommand;
+const IpcServer = @import("./linux_ipc_server.zig").IpcServer;
+
+const log = std.log.scoped(.linux_ipc);
+
+pub const LinuxIpc = struct {
+    const Self = @This();
+
+    allocator: std.mem.Allocator,
+    state_actor: ?*StateActor,
+    server: ?IpcServer = null,
+
+    pub fn init(allocator: std.mem.Allocator, state_actor: ?*StateActor) !*Self {
+        const self = try allocator.create(Self);
+        self.* = .{
+            .allocator = allocator,
+            .state_actor = state_actor,
+            .server = null,
+        };
+        return self;
+    }
+
+    pub fn deinit(context: *anyopaque) void {
+        const self: *Self = @ptrCast(@alignCast(context));
+        if (self.server) |*server| {
+            server.deinit();
+            self.server = null;
+        }
+        self.allocator.destroy(self);
+    }
+
+    pub fn start(context: *anyopaque) !void {
+        const self: *Self = @ptrCast(@alignCast(context));
+        if (self.server != null) {
+            return;
+        }
+
+        const state_actor = self.state_actor orelse return error.StateActorRequired;
+        self.server = try IpcServer.init(self.allocator, state_actor);
+        errdefer {
+            if (self.server) |*server| {
+                server.deinit();
+                self.server = null;
+            }
+        }
+        try self.server.?.start();
+    }
+
+    pub fn sendCommand(context: *anyopaque, command: IpcCommand) !void {
+        const self: *Self = @ptrCast(@alignCast(context));
+        try IpcServer.sendIpcCommand(self.allocator, command);
+    }
+
+    pub fn ipc(self: *Self) Ipc {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .start = start,
+                .sendCommand = sendCommand,
+                .deinit = deinit,
+            },
+        };
+    }
+};

--- a/src/ipc/linux/linux_ipc_server.zig
+++ b/src/ipc/linux/linux_ipc_server.zig
@@ -1,0 +1,270 @@
+const std = @import("std");
+const assert = std.debug.assert;
+const StateActor = @import("../../state_actor.zig").StateActor;
+const IpcCommand = @import("../ipc.zig").IpcCommand;
+
+const SOCKET_FILE_NAME = "spacecap.sock";
+const log = std.log.scoped(.linux_ipc_server);
+
+const RequestPayload = enum(u8) {
+    wake = 0,
+    save_replay = 1,
+
+    pub fn value(self: @This()) u8 {
+        return @intFromEnum(self);
+    }
+};
+
+const ResponsePayload = enum(u8) {
+    ok = 0,
+    unknown_command = 1,
+    request_failed = 2,
+
+    pub fn value(self: @This()) u8 {
+        return @intFromEnum(self);
+    }
+};
+
+pub const IpcServer = struct {
+    const Self = @This();
+
+    allocator: std.mem.Allocator,
+    state_actor: *StateActor,
+    socket_path: ?[]u8 = null,
+    listen_socket: ?std.posix.socket_t = null,
+    thread: ?std.Thread = null,
+    stop_requested: std.atomic.Value(bool) = .init(false),
+
+    pub fn init(allocator: std.mem.Allocator, state_actor: *StateActor) !Self {
+        return .{
+            .allocator = allocator,
+            .state_actor = state_actor,
+            .socket_path = try getSocketPath(allocator),
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.stop();
+
+        if (self.socket_path) |socket_path| {
+            self.allocator.free(socket_path);
+            self.socket_path = null;
+        }
+    }
+
+    pub fn start(self: *Self) !void {
+        assert(self.socket_path != null);
+        self.listen_socket = bindListeningSocket(self.socket_path.?) catch |err| switch (err) {
+            error.SocketAlreadyActive => {
+                log.warn("[start] IPC server disabled: another process is listening on {s}", .{self.socket_path.?});
+                return;
+            },
+            else => return err,
+        };
+
+        self.stop_requested.store(false, .release);
+        self.thread = try std.Thread.spawn(.{}, serverThread, .{self});
+    }
+
+    pub fn stop(self: *Self) void {
+        if (self.listen_socket == null and self.thread == null) {
+            return;
+        }
+
+        self.stop_requested.store(true, .release);
+
+        if (self.socket_path) |socket_path| {
+            const wake = std.net.connectUnixSocket(socket_path) catch null;
+            if (wake) |stream| {
+                defer stream.close();
+                stream.writeAll(&[_]u8{RequestPayload.wake.value()}) catch {};
+            }
+        }
+
+        if (self.thread) |thread| {
+            thread.join();
+            self.thread = null;
+        }
+
+        if (self.listen_socket) |listen_socket| {
+            std.posix.close(listen_socket);
+            self.listen_socket = null;
+        }
+
+        if (self.socket_path) |socket_path| {
+            removeSocketFile(socket_path) catch |err| {
+                log.warn("[stop] failed to remove IPC socket file {s}: {}", .{ socket_path, err });
+            };
+        }
+    }
+
+    fn serverThread(self: *Self) void {
+        assert(self.listen_socket != null);
+        while (true) {
+            if (self.stop_requested.load(.acquire)) {
+                break;
+            }
+
+            const client_socket = std.posix.accept(
+                self.listen_socket.?,
+                null,
+                null,
+                std.posix.SOCK.CLOEXEC,
+            ) catch |err| {
+                if (self.stop_requested.load(.acquire)) {
+                    break;
+                }
+                switch (err) {
+                    error.ConnectionAborted,
+                    error.ConnectionResetByPeer,
+                    => continue,
+                    else => {
+                        log.err("[serverThread] IPC accept failed: {}", .{err});
+                        continue;
+                    },
+                }
+            };
+            defer std.posix.close(client_socket);
+
+            handleClient(self, client_socket);
+        }
+    }
+
+    fn handleClient(self: *Self, client_socket: std.posix.socket_t) void {
+        const stream: std.net.Stream = .{ .handle = client_socket };
+        var command_buffer: [1]u8 = undefined;
+        const command_len = stream.read(&command_buffer) catch |err| switch (err) {
+            error.ConnectionResetByPeer,
+            => return,
+            else => {
+                log.warn("[handleClient] failed to read IPC command: {}", .{err});
+                return;
+            },
+        };
+        if (command_len == 0) {
+            log.warn("[handleClient] command_len is 0", .{});
+            return;
+        }
+
+        if (self.stop_requested.load(.acquire)) {
+            return;
+        }
+
+        const payload = std.enums.fromInt(RequestPayload, command_buffer[0]) orelse {
+            stream.writeAll(&[_]u8{ResponsePayload.unknown_command.value()}) catch |err| {
+                log.err("[handleClient] failed to write response: {}", .{err});
+            };
+            return;
+        };
+
+        log.info("[handleClient] message received: {}", .{payload});
+        switch (payload) {
+            // Used to close the socket.
+            .wake => return,
+            .save_replay => {
+                self.state_actor.dispatch(.save_replay) catch |err| {
+                    log.err("[handleClient] failed to dispatch save_replay from IPC command: {}", .{err});
+                    stream.writeAll(&[_]u8{ResponsePayload.request_failed.value()}) catch {};
+                    return;
+                };
+                stream.writeAll(&[_]u8{ResponsePayload.ok.value()}) catch {};
+                return;
+            },
+        }
+    }
+
+    /// Send a message to the server. This will only be used in
+    /// Spacecap CLI mode (separate from the running process.
+    pub fn sendIpcCommand(allocator: std.mem.Allocator, command: IpcCommand) !void {
+        const socket_path = try getSocketPath(allocator);
+        defer allocator.free(socket_path);
+        log.debug("[sendIpcCommand] using socket: {s}", .{socket_path});
+
+        const stream = std.net.connectUnixSocket(socket_path) catch |err| switch (err) {
+            error.FileNotFound,
+            error.ConnectionRefused,
+            error.ConnectionResetByPeer,
+            => return error.SpacecapNotRunning,
+            error.AccessDenied,
+            error.PermissionDenied,
+            => return error.IpcPermissionDenied,
+            else => return err,
+        };
+        defer stream.close();
+
+        const request_payload: RequestPayload = switch (command) {
+            .save_replay => .save_replay,
+        };
+        try stream.writeAll(&[_]u8{request_payload.value()});
+
+        var response_buffer: [1]u8 = undefined;
+        const response_len = stream.read(&response_buffer) catch |err| switch (err) {
+            error.ConnectionResetByPeer,
+            => return error.RequestFailed,
+            else => return err,
+        };
+        if (response_len == 0) {
+            return error.EmptyResponse;
+        }
+
+        const response_payload = std.enums.fromInt(ResponsePayload, response_buffer[0]) orelse {
+            return error.InvalidResponse;
+        };
+
+        log.info("[sendIpcCommand] response: {}", .{response_payload});
+
+        switch (response_payload) {
+            .ok => return,
+            .request_failed => return error.RequestFailed,
+            .unknown_command => return error.RequestRejected,
+        }
+    }
+
+    fn bindListeningSocket(socket_path: []const u8) !std.posix.socket_t {
+        const listen_socket = try std.posix.socket(
+            std.posix.AF.UNIX,
+            std.posix.SOCK.STREAM | std.posix.SOCK.CLOEXEC,
+            0,
+        );
+        errdefer std.posix.close(listen_socket);
+
+        var address = try std.net.Address.initUnix(socket_path);
+        std.posix.bind(listen_socket, &address.any, address.getOsSockLen()) catch |err| switch (err) {
+            error.AddressInUse => {
+                const existing = std.net.connectUnixSocket(socket_path);
+                if (existing) |stream| {
+                    stream.close();
+                    return error.SocketAlreadyActive;
+                } else |connect_err| switch (connect_err) {
+                    error.ConnectionRefused,
+                    error.FileNotFound,
+                    => {
+                        try removeSocketFile(socket_path);
+                        try std.posix.bind(listen_socket, &address.any, address.getOsSockLen());
+                    },
+                    else => return err,
+                }
+            },
+            else => return err,
+        };
+
+        try std.posix.listen(listen_socket, 16);
+        return listen_socket;
+    }
+
+    /// Must be freed by the caller.
+    fn getSocketPath(allocator: std.mem.Allocator) ![]u8 {
+        if (std.posix.getenv("XDG_RUNTIME_DIR")) |runtime_dir| {
+            return std.fs.path.join(allocator, &.{ runtime_dir, SOCKET_FILE_NAME });
+        }
+
+        return std.fmt.allocPrint(allocator, "/tmp/spacecap-{}.sock", .{std.posix.getuid()});
+    }
+
+    fn removeSocketFile(socket_path: []const u8) !void {
+        std.fs.cwd().deleteFile(socket_path) catch |err| switch (err) {
+            error.FileNotFound => {},
+            else => return err,
+        };
+    }
+};

--- a/src/ipc/platform_ipc.zig
+++ b/src/ipc/platform_ipc.zig
@@ -1,0 +1,6 @@
+const Util = @import("../util.zig");
+
+pub const PlatformIpc = if (Util.isLinux())
+    @import("./linux/linux_ipc.zig").LinuxIpc
+else
+    @import("./windows/windows_ipc.zig").WindowsIpc;

--- a/src/ipc/windows/windows_ipc.zig
+++ b/src/ipc/windows/windows_ipc.zig
@@ -1,0 +1,45 @@
+const std = @import("std");
+const StateActor = @import("../../state_actor.zig").StateActor;
+const Ipc = @import("../ipc.zig").Ipc;
+const IpcCommand = @import("../ipc.zig").IpcCommand;
+
+pub const WindowsIpc = struct {
+    const Self = @This();
+
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator, state_actor: ?*StateActor) !*Self {
+        _ = state_actor;
+        const self = try allocator.create(Self);
+        self.* = .{
+            .allocator = allocator,
+        };
+        return self;
+    }
+
+    pub fn start(context: *anyopaque) !void {
+        _ = context;
+    }
+
+    pub fn deinit(context: *anyopaque) void {
+        const self: *Self = @ptrCast(@alignCast(context));
+        self.allocator.destroy(self);
+    }
+
+    pub fn sendCommand(context: *anyopaque, command: IpcCommand) !void {
+        _ = context;
+        _ = command;
+        return error.UnsupportedPlatform;
+    }
+
+    pub fn ipc(self: *Self) Ipc {
+        return .{
+            .ptr = self,
+            .vtable = &.{
+                .start = start,
+                .sendCommand = sendCommand,
+                .deinit = deinit,
+            },
+        };
+    }
+};

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,7 +5,10 @@ const StateActor = @import("./state_actor.zig").StateActor;
 const Util = @import("./util.zig");
 const sdl = @import("./ui/sdl.zig");
 const PlatformCaptureSetup = @import("./capture/platform_capture_setup.zig").PlatformCaptureSetup;
+const args = @import("./args.zig");
+const PlatformIpc = @import("./ipc/platform_ipc.zig").PlatformIpc;
 
+// TODO: refactor these into platform files
 const PlatformVideoCapture = if (Util.isLinux())
     @import("./capture/video/linux/linux_pipewire_dma_capture.zig").LinuxPipewireDmaCapture
 else
@@ -29,6 +32,54 @@ pub fn main() !void {
 
     const allocator = gpa.allocator();
 
+    const parsed_args: ?args.Args = args.parse(allocator);
+
+    if (try cli_app(allocator, parsed_args)) {
+        return;
+    }
+    try gui_app(allocator, parsed_args);
+}
+
+/// Handle command-line-only modes and return whether execution
+/// should stop before launching the full app.
+fn cli_app(allocator: std.mem.Allocator, parsed_args: ?args.Args) !bool {
+    if (!comptime Util.isLinux()) return false;
+    const linux_args = parsed_args orelse return false;
+
+    switch (linux_args) {
+        .send => |send_cmd| switch (send_cmd) {
+            .@"save-replay" => {
+                const _ipc = try PlatformIpc.init(allocator, null);
+                var ipc = _ipc.ipc();
+                defer ipc.deinit();
+
+                ipc.sendCommand(.save_replay) catch |err| {
+                    switch (err) {
+                        error.SpacecapNotRunning => {
+                            std.debug.print("spacecap is not running.\n", .{});
+                        },
+                        error.IpcPermissionDenied => {
+                            std.debug.print("permission denied while contacting spacecap IPC socket.\n", .{});
+                        },
+                        else => {
+                            std.debug.print("failed to send save replay command: {}\n", .{err});
+                        },
+                    }
+                    std.process.exit(1);
+                };
+
+                return true;
+            },
+        },
+    }
+
+    return false;
+}
+
+/// Run the full Spacecap application, start global shortcuts + IPC server,
+/// and launch the UI/event loop.
+fn gui_app(allocator: std.mem.Allocator, parsed_args: ?args.Args) !void {
+    _ = parsed_args;
     PlatformCaptureSetup.init();
     defer PlatformCaptureSetup.deinit();
 
@@ -69,6 +120,11 @@ pub fn main() !void {
         }
     };
     const state_thread = try std.Thread.spawn(.{}, StateThread.run, .{state_actor});
+
+    const _ipc = try PlatformIpc.init(allocator, state_actor);
+    var ipc = _ipc.ipc();
+    try ipc.start();
+    defer ipc.deinit();
 
     const ui = try UI.init(allocator, state_actor, vulkan);
     defer ui.deinit();


### PR DESCRIPTION
- Run a Unix socket server on Linux.
- Add CLI opens to send messages to the socket server. This will enable global shortcuts on Linux compositors that do not support XDG Global Shortcuts.

closes #54