### PR TITLE
chore: remove dependency of gobject

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -94,11 +94,6 @@ fn add_linux_dependencies(
     // For Zig projects, add the `pipewire` module.
     exe.root_module.addImport("pipewire", pipewire.module("pipewire"));
 
-    const gobject = b.dependency("gobject", .{});
-    exe.root_module.addImport("glib", gobject.module("glib2"));
-    exe.root_module.addImport("gio", gobject.module("gio2"));
-    exe.root_module.addImport("gobject", gobject.module("gobject2"));
-
     exe.root_module.linkSystemLibrary("glib-2.0", .{});
     exe.root_module.linkSystemLibrary("gio-2.0", .{});
     exe.root_module.linkSystemLibrary("gobject-2.0", .{});

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -86,10 +86,6 @@
             .url = "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n8.0.1.tar.gz",
             .hash = "N-V-__8AAH4RHQXHEafp_hkUel3EMeK1wjHBfaIYYxYsKdiM",
         },
-        .gobject = .{
-            .url = "https://github.com/ianprime0509/zig-gobject/releases/download/v0.3.0/bindings-gnome47.tar.zst",
-            .hash = "gobject-0.3.0-Skun7IrmdQHh-PhvmchG9AKnrR2RFS5EhBe5oedb0ITv",
-        },
         .pipewire = .{
             .url = "https://github.com/mgerb/pipewire/archive/refs/heads/dev.tar.gz",
             .hash = "pipewire-1.6.2-tKslQ3LyEgC050NwrrKyjJjEXbO-M_CvmyVMu3FLLoJd",

--- a/src/common/linux/gio.zig
+++ b/src/common/linux/gio.zig
@@ -1,0 +1,3 @@
+pub const c = @cImport({
+    @cInclude("gio/gio.h");
+});

--- a/src/file_picker/linux/xdg_desktop_portal_file_picker.zig
+++ b/src/file_picker/linux/xdg_desktop_portal_file_picker.zig
@@ -3,8 +3,8 @@ const Allocator = std.mem.Allocator;
 const TokenManager = @import("../../common/linux/token_manager.zig");
 const FilePicker = @import("../file_picker.zig").FilePicker;
 const FilePickerError = @import("../file_picker.zig").FilePickerError;
-const glib = @import("glib");
-const gio = @import("gio");
+
+const c = @import("../../common/linux/gio.zig").c;
 
 const log = std.log.scoped(.xdg_desktop_portal_file_picker);
 
@@ -15,34 +15,38 @@ const REQUEST_INTERFACE: [:0]const u8 = "org.freedesktop.portal.Request";
 const OPEN_FILE_METHOD: [:0]const u8 = "OpenFile";
 const RESPONSE_SIGNAL: [:0]const u8 = "Response";
 
-fn map_g_error(err: *glib.Error) ?(FilePickerError || anyerror) {
-    if (err.f_domain == gio.DBusError.quark()) {
-        if (err.f_code == @intFromEnum(gio.DBusError.service_unknown) or err.f_code == @intFromEnum(gio.DBusError.name_has_no_owner)) {
+fn variant_type(comptime signature: [:0]const u8) *const c.GVariantType {
+    return @ptrCast(signature.ptr);
+}
+
+fn map_g_error(err: *c.GError) ?(FilePickerError || anyerror) {
+    if (err.domain == c.g_dbus_error_quark()) {
+        if (err.code == c.G_DBUS_ERROR_SERVICE_UNKNOWN or err.code == c.G_DBUS_ERROR_NAME_HAS_NO_OWNER) {
             return error.PortalServiceNotFound;
         }
     }
-    if (err.f_domain == gio.ioErrorQuark() and err.f_code == @intFromEnum(gio.IOErrorEnum.cancelled)) {
+    if (err.domain == c.g_io_error_quark() and err.code == c.G_IO_ERROR_CANCELLED) {
         return FilePickerError.PickerCancelled;
     }
     return null;
 }
 
 const OpenDirectoryPickerContext = struct {
-    loop: *glib.MainLoop,
+    loop: *c.GMainLoop,
     response_code: u32 = 2,
-    response_data: ?*glib.Variant = null,
+    response_data: ?*c.GVariant = null,
 };
 
 pub const XdgDesktopPortalFilePicker = struct {
     const Self = @This();
 
-    dbus: *gio.DBusConnection,
+    dbus: *c.GDBusConnection,
 
     pub fn init() !Self {
-        var err: ?*glib.Error = null;
-        defer if (err) |e| e.free();
+        var err: ?*c.GError = null;
+        defer if (err) |e| c.g_error_free(e);
 
-        const dbus = gio.busGetSync(.session, null, &err) orelse {
+        const dbus = c.g_bus_get_sync(c.G_BUS_TYPE_SESSION, null, &err) orelse {
             if (err) |g_err| {
                 if (map_g_error(g_err)) |picker_err| {
                     return picker_err;
@@ -57,58 +61,58 @@ pub const XdgDesktopPortalFilePicker = struct {
     }
 
     fn open_directory_picker_response(
-        _: *gio.DBusConnection,
-        _: ?[*:0]const u8,
-        _: [*:0]const u8,
-        _: [*:0]const u8,
-        _: [*:0]const u8,
-        parameters: *glib.Variant,
+        _: ?*c.GDBusConnection,
+        _: [*c]const u8,
+        _: [*c]const u8,
+        _: [*c]const u8,
+        _: [*c]const u8,
+        parameters: ?*c.GVariant,
         user_data: ?*anyopaque,
     ) callconv(.c) void {
         const ctx: *OpenDirectoryPickerContext = @ptrCast(@alignCast(user_data));
-        parameters.get("(u@a{sv})", &ctx.response_code, &ctx.response_data);
-        ctx.loop.quit();
+        c.g_variant_get(parameters.?, "(u@a{sv})", &ctx.response_code, &ctx.response_data);
+        c.g_main_loop_quit(ctx.loop);
     }
 
-    fn make_open_directory_picker_payload(request_token: [:0]const u8, initial_directory: ?[:0]const u8) *glib.Variant {
-        var options: glib.VariantBuilder = undefined;
-        glib.VariantBuilder.init(&options, glib.VariantType.checked("a{sv}"));
-        options.add("{sv}", "handle_token", glib.Variant.newString(request_token.ptr));
-        options.add("{sv}", "directory", glib.Variant.newBoolean(1));
-        options.add("{sv}", "modal", glib.Variant.newBoolean(1));
+    fn make_open_directory_picker_payload(request_token: [:0]const u8, initial_directory: ?[:0]const u8) *c.GVariant {
+        var options: c.GVariantBuilder = undefined;
+        c.g_variant_builder_init(&options, variant_type("a{sv}"));
+        c.g_variant_builder_add(&options, "{sv}", "handle_token", c.g_variant_new_string(request_token.ptr));
+        c.g_variant_builder_add(&options, "{sv}", "directory", c.g_variant_new_boolean(1));
+        c.g_variant_builder_add(&options, "{sv}", "modal", c.g_variant_new_boolean(1));
         if (initial_directory) |directory| {
-            options.add("{sv}", "current_folder", glib.Variant.newBytestring(directory.ptr));
+            c.g_variant_builder_add(&options, "{sv}", "current_folder", c.g_variant_new_bytestring(directory.ptr));
         }
 
-        return glib.Variant.new(
+        return c.g_variant_new(
             "(ss@a{sv})",
             "",
             "Select Output Directory",
-            options.end(),
-        );
+            c.g_variant_builder_end(&options),
+        ).?;
     }
 
-    fn selected_directory_from_result(allocator: Allocator, result: *glib.Variant) ![]u8 {
-        var result_dict: glib.VariantDict = undefined;
-        glib.VariantDict.init(&result_dict, result);
-        defer result_dict.clear();
+    fn selected_directory_from_result(allocator: Allocator, result: *c.GVariant) ![]u8 {
+        var result_dict: c.GVariantDict = undefined;
+        c.g_variant_dict_init(&result_dict, result);
+        defer c.g_variant_dict_clear(&result_dict);
 
-        const uris = result_dict.lookupValue("uris", glib.VariantType.checked("as")) orelse {
+        const uris = c.g_variant_dict_lookup_value(&result_dict, "uris", variant_type("as")) orelse {
             return error.PickerResultMissingUris;
         };
-        defer uris.unref();
+        defer c.g_variant_unref(uris);
 
         var uri_count: usize = 0;
-        const uri_values = uris.getStrv(&uri_count);
-        defer glib.free(@ptrCast(@constCast(uri_values)));
+        const uri_values = c.g_variant_get_strv(uris, &uri_count);
+        defer c.g_free(@ptrCast(@constCast(uri_values)));
 
         if (uri_count == 0) {
             return error.PickerResultMissingUris;
         }
 
         const first_uri = uri_values[0] orelse return error.PickerResultMissingUris;
-        const file_path = glib.filenameFromUri(first_uri, null, null) orelse return error.FileUriToPathFailed;
-        defer glib.free(file_path);
+        const file_path = c.g_filename_from_uri(first_uri, null, null) orelse return error.FileUriToPathFailed;
+        defer c.g_free(file_path);
 
         return allocator.dupe(u8, std.mem.span(file_path));
     }
@@ -129,64 +133,66 @@ pub const XdgDesktopPortalFilePicker = struct {
             null;
         defer if (initial_directory_z) |directory| allocator.free(directory);
 
-        const unique_name = std.mem.span(self.dbus.getUniqueName().?);
+        const unique_name = std.mem.span(c.g_dbus_connection_get_unique_name(self.dbus).?);
         const request_path = try TokenManager.get_request_path(allocator, unique_name[1..], request_token);
         defer allocator.free(request_path);
 
-        const loop = glib.MainLoop.new(null, 0);
-        defer loop.unref();
+        const loop = c.g_main_loop_new(null, 0) orelse return error.GMainLoopNewFailed;
+        defer c.g_main_loop_unref(loop);
 
         var ctx = OpenDirectoryPickerContext{ .loop = loop };
-        var subscription_id = self.dbus.signalSubscribe(
+        var subscription_id = c.g_dbus_connection_signal_subscribe(
+            self.dbus,
             null,
             REQUEST_INTERFACE.ptr,
             RESPONSE_SIGNAL.ptr,
             request_path.ptr,
             null,
-            .{},
+            c.G_DBUS_SIGNAL_FLAGS_NONE,
             open_directory_picker_response,
             &ctx,
             null,
         );
         defer {
             if (subscription_id != 0) {
-                self.dbus.signalUnsubscribe(subscription_id);
+                c.g_dbus_connection_signal_unsubscribe(self.dbus, subscription_id);
             }
         }
 
         const payload = make_open_directory_picker_payload(request_token, initial_directory_z);
-        var err: ?*glib.Error = null;
-        const request_handle = self.dbus.callSync(
+        var err: ?*c.GError = null;
+        const request_handle = c.g_dbus_connection_call_sync(
+            self.dbus,
             DBUS_DESTINATION.ptr,
             DBUS_OBJECT_PATH.ptr,
             FILE_CHOOSER_INTERFACE.ptr,
             OPEN_FILE_METHOD.ptr,
             payload,
             null,
-            .{},
+            c.G_DBUS_CALL_FLAGS_NONE,
             -1,
             null,
             &err,
         );
         defer {
             if (request_handle != null) {
-                request_handle.?.unref();
+                c.g_variant_unref(request_handle.?);
             }
         }
 
         if (err) |g_err| {
-            defer g_err.free();
+            defer c.g_error_free(g_err);
             if (map_g_error(g_err)) |picker_err| {
                 return picker_err;
             }
-            log.err("directory picker request failed: {s}", .{g_err.f_message.?});
+            log.err("directory picker request failed: {s}", .{g_err.message.?});
             return error.OpenDirectoryPickerFailed;
         }
 
         const request_handle_value = request_handle orelse return error.OpenDirectoryPickerFailed;
-        const actual_request_path_variant = request_handle_value.getChildValue(0);
-        defer actual_request_path_variant.unref();
-        const actual_request_path = actual_request_path_variant.getString(null);
+        const actual_request_path_variant = c.g_variant_get_child_value(request_handle_value, 0);
+        defer c.g_variant_unref(actual_request_path_variant);
+        const actual_request_path = c.g_variant_get_string(actual_request_path_variant, null);
         const actual_request_path_str = std.mem.span(actual_request_path);
 
         if (!std.mem.eql(u8, actual_request_path_str, request_path)) {
@@ -194,21 +200,22 @@ pub const XdgDesktopPortalFilePicker = struct {
                 "directory picker returned unexpected request path, resubscribing: expected={s} actual={s}",
                 .{ request_path, actual_request_path_str },
             );
-            self.dbus.signalUnsubscribe(subscription_id);
-            subscription_id = self.dbus.signalSubscribe(
+            c.g_dbus_connection_signal_unsubscribe(self.dbus, subscription_id);
+            subscription_id = c.g_dbus_connection_signal_subscribe(
+                self.dbus,
                 null,
                 REQUEST_INTERFACE.ptr,
                 RESPONSE_SIGNAL.ptr,
                 actual_request_path,
                 null,
-                .{},
+                c.G_DBUS_SIGNAL_FLAGS_NONE,
                 open_directory_picker_response,
                 &ctx,
                 null,
             );
         }
 
-        loop.run();
+        c.g_main_loop_run(loop);
 
         switch (ctx.response_code) {
             0 => {},
@@ -217,13 +224,13 @@ pub const XdgDesktopPortalFilePicker = struct {
         }
 
         const result = ctx.response_data orelse return error.OpenDirectoryPickerFailed;
-        defer result.unref();
+        defer c.g_variant_unref(result);
 
         return selected_directory_from_result(allocator, result);
     }
 
     pub fn deinit(self: *Self) void {
-        self.dbus.unref();
+        c.g_object_unref(self.dbus);
     }
 
     pub fn file_picker(self: *Self) FilePicker {

--- a/src/global_shortcuts/linux/xdg_desktop_portal_global_shortcuts.zig
+++ b/src/global_shortcuts/linux/xdg_desktop_portal_global_shortcuts.zig
@@ -6,9 +6,7 @@ const TokenStorage = @import("../../common/linux/token_storage.zig");
 const GlobalShortcuts = @import("../global_shortcuts.zig").GlobalShortcuts;
 const assert = std.debug.assert;
 
-const glib = @import("glib");
-const gobject = @import("gobject");
-const gio = @import("gio");
+const c = @import("../../common/linux/gio.zig").c;
 
 const log = std.log.scoped(.xdg_desktop_portal_global_shortcuts);
 
@@ -23,10 +21,10 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
     const Token = [16]u8;
 
     allocator: std.mem.Allocator,
-    dbus: *gio.DBusConnection,
-    main_loop: ?*glib.MainLoop = null,
+    dbus: *c.GDBusConnection,
+    main_loop: ?*c.GMainLoop = null,
     run_thread: ?std.Thread = null,
-    ctx: ?*glib.MainContext = null,
+    ctx: ?*c.GMainContext = null,
     // actions: *Actions,
     actions: Actions,
     session_token: ?[:0]u8 = null,
@@ -48,11 +46,12 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
         const self = try allocator.create(Self);
         errdefer allocator.destroy(self);
 
-        const g_error: ?*?*glib.Error = null;
-        const dbus = gio.busGetSync(.session, null, g_error) orelse return error.Dbus;
+        var g_error: ?*c.GError = null;
+        const dbus = c.g_bus_get_sync(c.G_BUS_TYPE_SESSION, null, &g_error) orelse return error.Dbus;
+        defer if (g_error) |err| c.g_error_free(err);
 
         if (g_error) |err| {
-            log.err("{s}\n", .{err.*.?.f_message});
+            log.err("{s}\n", .{err.message.?});
             return error.BusGetSync;
         }
 
@@ -82,7 +81,7 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
         stop(self);
         self.close();
 
-        self.dbus.unref();
+        c.g_object_unref(self.dbus);
 
         if (self.handle) |handle| {
             self.allocator.free(handle);
@@ -105,25 +104,26 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
 
     fn close(self: *Self) void {
         if (self.response_subscription != 0) {
-            self.dbus.signalUnsubscribe(self.response_subscription);
+            c.g_dbus_connection_signal_unsubscribe(self.dbus, self.response_subscription);
             self.response_subscription = 0;
         }
 
         if (self.activate_subscription != 0) {
-            self.dbus.signalUnsubscribe(self.activate_subscription);
+            c.g_dbus_connection_signal_unsubscribe(self.dbus, self.activate_subscription);
             self.activate_subscription = 0;
         }
 
         if (self.handle) |handle| {
             // Close existing session
-            self.dbus.call(
+            c.g_dbus_connection_call(
+                self.dbus,
                 "org.freedesktop.portal.Desktop",
-                handle,
+                handle.ptr,
                 "org.freedesktop.portal.Session",
                 "Close",
                 null,
                 null,
-                .{},
+                c.G_DBUS_CALL_FLAGS_NONE,
                 -1,
                 null,
                 null,
@@ -149,25 +149,25 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
 
         const RunThread = struct {
             pub fn run(_self: *Self) void {
-                _self.ctx = glib.MainContext.new();
+                _self.ctx = c.g_main_context_new();
                 defer {
-                    _self.ctx.?.unref();
+                    c.g_main_context_unref(_self.ctx.?);
                     _self.ctx = null;
                 }
-                glib.MainContext.pushThreadDefault(_self.ctx.?);
-                defer glib.MainContext.popThreadDefault(_self.ctx.?);
+                c.g_main_context_push_thread_default(_self.ctx.?);
+                defer c.g_main_context_pop_thread_default(_self.ctx.?);
 
                 _self.request(.{ .create_session = .{ .restore_session = true } }) catch |err| {
                     log.err("create session error: {}\n", .{err});
                 };
 
-                const main_loop = glib.MainLoop.new(_self.ctx.?, 0);
+                const main_loop = c.g_main_loop_new(_self.ctx.?, 0) orelse return;
                 _self.main_loop = main_loop;
                 defer {
-                    main_loop.unref();
+                    c.g_main_loop_unref(main_loop);
                     _self.main_loop = null;
                 }
-                main_loop.run();
+                c.g_main_loop_run(main_loop);
             }
         };
 
@@ -178,8 +178,8 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
     pub fn stop(context: *anyopaque) void {
         const self: *Self = @ptrCast(@alignCast(context));
         if (self.main_loop) |main_loop| {
-            if (main_loop.isRunning() != 0) {
-                main_loop.quit();
+            if (c.g_main_loop_is_running(main_loop) != 0) {
+                c.g_main_loop_quit(main_loop);
             }
         }
     }
@@ -190,7 +190,7 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
         // be done in the context of the main loop, otherwise
         // nothing will happen.
         if (self.ctx) |ctx| {
-            glib.MainContext.invoke(ctx, _open_shortcuts, self);
+            c.g_main_context_invoke(ctx, _open_shortcuts, self);
         }
     }
 
@@ -212,33 +212,37 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
         // TODO: Need to figure out how to get the activation token;
         const activation_token = "todo";
 
-        const payload = glib.Variant.newParsed(
+        const payload = c.g_variant_new_parsed(
             "(%o, '', {'activation_token': <%s>})",
             handle.ptr,
             activation_token.ptr,
         );
 
-        _ = self.dbus.callSync(
+        const result = c.g_dbus_connection_call_sync(
+            self.dbus,
             "org.freedesktop.portal.Desktop",
             "/org/freedesktop/portal/desktop",
             "org.freedesktop.portal.GlobalShortcuts",
             "ConfigureShortcuts",
             payload,
             null,
-            .{},
+            c.G_DBUS_CALL_FLAGS_NONE,
             -1,
             null,
             null,
         );
+        if (result) |variant| {
+            c.g_variant_unref(variant);
+        }
     }
 
     fn shortcut_activated(
-        _: *gio.DBusConnection,
-        _: ?[*:0]const u8,
-        _: [*:0]const u8,
-        _: [*:0]const u8,
-        _: [*:0]const u8,
-        params: *glib.Variant,
+        _: ?*c.GDBusConnection,
+        _: [*c]const u8,
+        _: [*c]const u8,
+        _: [*c]const u8,
+        _: [*c]const u8,
+        params: ?*c.GVariant,
         ud: ?*anyopaque,
     ) callconv(.c) void {
         const self: *Self = @ptrCast(@alignCast(ud));
@@ -246,7 +250,7 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
         // 2nd value in the tuple is the activated shortcut ID
         // See https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GlobalShortcuts.html#org-freedesktop-portal-globalshortcuts-activated
         var shortcut_idZ: [*:0]const u8 = undefined;
-        params.getChild(1, "&s", &shortcut_idZ);
+        c.g_variant_get_child(params.?, 1, "&s", &shortcut_idZ);
         log.debug("activated={s}", .{shortcut_idZ});
         const shortcut_id = std.mem.span(shortcut_idZ);
 
@@ -284,7 +288,7 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
             self: Method,
             shortcuts: *Self,
             request_token: [:0]const u8,
-        ) ?*glib.Variant {
+        ) ?*c.GVariant {
             switch (self) {
                 // See https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GlobalShortcuts.html#org-freedesktop-portal-globalshortcuts-createsession
                 .create_session => {
@@ -299,7 +303,7 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
 
                     assert(shortcuts.session_token != null);
 
-                    return glib.Variant.newParsed(
+                    return c.g_variant_new_parsed(
                         "({'handle_token': <%s>, 'session_handle_token': <%s>},)",
                         request_token.ptr,
                         shortcuts.session_token.?.ptr,
@@ -309,25 +313,27 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
                 .bind_shortcuts => {
                     const handle = shortcuts.handle orelse return null;
 
-                    const bind_type = glib.VariantType.new("a(sa{sv})");
-                    defer glib.free(bind_type);
+                    const bind_type = c.g_variant_type_new("a(sa{sv})");
+                    defer c.g_variant_type_free(bind_type);
 
-                    var binds: glib.VariantBuilder = undefined;
-                    glib.VariantBuilder.init(&binds, bind_type);
+                    var binds: c.GVariantBuilder = undefined;
+                    c.g_variant_builder_init(&binds, bind_type);
 
                     var iter = shortcuts.actions.iterator();
                     while (iter.next()) |entry| {
                         const action = shortcuts.actions.get(entry.key_ptr.*).?;
 
                         if (entry.value_ptr.trigger) |trigger| {
-                            binds.addParsed(
+                            c.g_variant_builder_add_parsed(
+                                &binds,
                                 "(%s, {'description': <%s>, 'preferred_trigger': <%s>})",
                                 entry.key_ptr.*.ptr,
                                 action.name.ptr,
                                 trigger.ptr,
                             );
                         } else {
-                            binds.addParsed(
+                            c.g_variant_builder_add_parsed(
+                                &binds,
                                 "(%s, {'description': <%s>})",
                                 entry.key_ptr.*.ptr,
                                 action.name.ptr,
@@ -335,24 +341,26 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
                         }
                     }
 
-                    return glib.Variant.newParsed(
+                    return c.g_variant_new_parsed(
                         "(%o, %*, '', {'handle_token': <%s>})",
                         handle.ptr,
-                        binds.end(),
+                        c.g_variant_builder_end(&binds),
                         request_token.ptr,
                     );
                 },
             }
         }
 
-        fn on_response(self: Method, shortcuts: *Self, vardict: *glib.Variant) void {
+        fn on_response(self: Method, shortcuts: *Self, vardict: *c.GVariant) void {
             switch (self) {
                 .create_session => {
                     var handle: ?[*:0]u8 = null;
-                    if (vardict.lookup("session_handle", "&s", &handle) == 0) {
+                    if (c.g_variant_lookup(vardict, "session_handle", "&s", &handle) == 0) {
+                        const response = c.g_variant_print(vardict, 1);
+                        defer c.g_free(response);
                         log.err(
                             "session handle not found in response={s}",
-                            .{vardict.print(@intFromBool(true))},
+                            .{response},
                         );
                         return;
                     }
@@ -365,13 +373,14 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
                     log.debug("session_handle={?s}", .{handle});
 
                     // Subscribe to keybind activations
-                    shortcuts.activate_subscription = shortcuts.dbus.signalSubscribe(
+                    shortcuts.activate_subscription = c.g_dbus_connection_signal_subscribe(
+                        shortcuts.dbus,
                         null,
                         "org.freedesktop.portal.GlobalShortcuts",
                         "Activated",
                         "/org/freedesktop/portal/desktop",
                         handle,
-                        .{ .match_arg0_path = true },
+                        c.G_DBUS_SIGNAL_FLAGS_MATCH_ARG0_PATH,
                         shortcut_activated,
                         shortcuts,
                         null,
@@ -385,20 +394,20 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
                 },
                 .bind_shortcuts => {
                     log.info("bind_shortcuts done\n", .{});
-                    var sc: ?*glib.Variant = null;
-                    assert(vardict.lookup("shortcuts", "@a(sa{sv})", &sc) == 1);
+                    var sc: ?*c.GVariant = null;
+                    assert(c.g_variant_lookup(vardict, "shortcuts", "@a(sa{sv})", &sc) == 1);
                     assert(sc != null);
 
-                    defer sc.?.unref();
+                    defer c.g_variant_unref(sc.?);
 
-                    var iter = sc.?.iterNew();
-                    defer iter.free();
+                    const iter = c.g_variant_iter_new(sc.?);
+                    defer c.g_variant_iter_free(iter);
 
                     var id: [*:0]const u8 = undefined;
-                    var props: *glib.Variant = undefined;
-                    while (iter.loop("(&s@a{sv})", &id, &props) != 0) {
+                    var props: *c.GVariant = undefined;
+                    while (c.g_variant_iter_loop(iter, "(&s@a{sv})", &id, &props) != 0) {
                         var trigger: [*:0]const u8 = undefined;
-                        assert(props.lookup("trigger_description", "&s", &trigger) == 1);
+                        assert(c.g_variant_lookup(props, "trigger_description", "&s", &trigger) == 1);
 
                         // NOTE: No longer used. See description of Actions.
                         // shortcuts.actions.updateTrigger(std.mem.span(id), std.mem.span(trigger)) catch unreachable;
@@ -449,23 +458,23 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
 
         const callbacks = struct {
             fn got_response_handle(
-                source: ?*gobject.Object,
-                res: *gio.AsyncResult,
+                source: [*c]c.GObject,
+                res: ?*c.GAsyncResult,
                 _: ?*anyopaque,
             ) callconv(.c) void {
-                const dbus_ = gobject.ext.cast(gio.DBusConnection, source.?).?;
+                const dbus_: *c.GDBusConnection = @ptrCast(@alignCast(source));
 
-                var err: ?*glib.Error = null;
-                defer if (err) |err_| err_.free();
+                var err: ?*c.GError = null;
+                defer if (err) |err_| c.g_error_free(err_);
 
-                const params_ = dbus_.callFinish(res, &err) orelse {
-                    if (err) |err_| log.err("request failed={s} ({})", .{
-                        err_.f_message orelse "(unknown)",
-                        err_.f_code,
-                    });
+                const params_ = c.g_dbus_connection_call_finish(dbus_, res.?, &err) orelse {
+                    if (err) |err_| {
+                        const message: [*c]const u8 = if (err_.message != null) err_.message else @ptrCast("(unknown)".ptr);
+                        log.err("request failed={s} ({})", .{ message, err_.code });
+                    }
                     return;
                 };
-                defer params_.unref();
+                defer c.g_variant_unref(params_);
 
                 // TODO: XDG recommends updating the signal subscription if the actual
                 // returned request path is not the same as the expected request
@@ -476,25 +485,26 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
 
             // See https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html#org-freedesktop-portal-request-response
             fn responded(
-                dbus: *gio.DBusConnection,
-                _: ?[*:0]const u8,
-                _: [*:0]const u8,
-                _: [*:0]const u8,
-                _: [*:0]const u8,
-                params_: *glib.Variant,
+                dbus: ?*c.GDBusConnection,
+                _: [*c]const u8,
+                _: [*c]const u8,
+                _: [*c]const u8,
+                _: [*c]const u8,
+                params_: ?*c.GVariant,
                 ud: ?*anyopaque,
             ) callconv(.c) void {
                 const self_: *Self = @ptrCast(@alignCast(ud));
 
                 // Unsubscribe from the response signal
                 if (self_.response_subscription != 0) {
-                    dbus.signalUnsubscribe(self_.response_subscription);
+                    c.g_dbus_connection_signal_unsubscribe(dbus.?, self_.response_subscription);
                     self_.response_subscription = 0;
                 }
 
                 var response: u32 = 0;
-                var vardict: ?*glib.Variant = null;
-                params_.get("(u@a{sv})", &response, &vardict);
+                var vardict: ?*c.GVariant = null;
+                c.g_variant_get(params_.?, "(u@a{sv})", &response, &vardict);
+                defer if (vardict) |dict| c.g_variant_unref(dict);
 
                 switch (response) {
                     0 => {
@@ -512,30 +522,32 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
         defer self.allocator.free(request_token);
 
         const payload = method.make_payload(self, request_token) orelse return;
-        var unique_name = std.mem.span(self.dbus.getUniqueName().?);
+        const unique_name = std.mem.span(c.g_dbus_connection_get_unique_name(self.dbus).?);
         const request_path = try TokenManager.get_request_path(self.allocator, unique_name[1..], request_token);
         defer self.allocator.free(request_path);
 
-        self.response_subscription = self.dbus.signalSubscribe(
+        self.response_subscription = c.g_dbus_connection_signal_subscribe(
+            self.dbus,
             null,
             "org.freedesktop.portal.Request",
             "Response",
             request_path,
             null,
-            .{},
+            c.G_DBUS_SIGNAL_FLAGS_NONE,
             callbacks.responded,
             self,
             null,
         );
 
-        self.dbus.call(
+        c.g_dbus_connection_call(
+            self.dbus,
             "org.freedesktop.portal.Desktop",
             "/org/freedesktop/portal/desktop",
             "org.freedesktop.portal.GlobalShortcuts",
             method.name(),
             payload,
             null,
-            .{},
+            c.G_DBUS_CALL_FLAGS_NONE,
             -1,
             null,
             callbacks.got_response_handle,


### PR DESCRIPTION
Going to work on upgrading to Zig 0.16.0. Each dependency makes this more difficult. This was not really needed anyway because already does a great job with importing C dependencies.