### PR TITLE
feat: ImGui dock builder layout

### DIFF
--- a/src/ui/dockspace.zig
+++ b/src/ui/dockspace.zig
@@ -1,0 +1,93 @@
+const c = @import("imguiz").imguiz;
+
+pub const LEFT_WINDOW_NAME = "left column";
+pub const VIDEO_WINDOW_NAME = "video preview";
+pub const BOTTOM_WINDOW_NAME = "bottom panel";
+
+const DOCKSPACE_WINDOW_NAME = "SpacecapDockSpace";
+const DOCKSPACE_ID = "spacecap-dockspace";
+
+// Flags
+const DOCK_NODE_FLAGS_DOCK_SPACE: c.ImGuiDockNodeFlags = 1 << 10;
+const DOCK_NODE_FLAGS_NO_TAB_BAR: c.ImGuiDockNodeFlags = 1 << 12;
+const DOCK_NODE_FLAGS_NO_WINDOW_MENU_BUTTON: c.ImGuiDockNodeFlags = 1 << 14;
+const PANE_DOCK_NODE_FLAGS = c.ImGuiDockNodeFlags_NoUndocking |
+    DOCK_NODE_FLAGS_NO_TAB_BAR |
+    DOCK_NODE_FLAGS_NO_WINDOW_MENU_BUTTON;
+
+// ----------------------------------------------------------------------------
+// These are not provided by imguiz because they are internal ImGui functions.
+// The docking API is still not final and these are subject to change.
+//
+// https://github.com/ocornut/imgui/wiki/Docking#programmatically-setting-up-docking-layout-dockbuider-api
+// ----------------------------------------------------------------------------
+extern fn ImGui_DockBuilderGetNode(node_id: c.ImGuiID) ?*anyopaque;
+extern fn ImGui_DockBuilderRemoveNode(node_id: c.ImGuiID) void;
+extern fn ImGui_DockBuilderAddNodeEx(node_id: c.ImGuiID, flags: c.ImGuiDockNodeFlags) c.ImGuiID;
+extern fn ImGui_DockBuilderSetNodePos(node_id: c.ImGuiID, pos: c.ImVec2) void;
+extern fn ImGui_DockBuilderSetNodeSize(node_id: c.ImGuiID, size: c.ImVec2) void;
+extern fn ImGui_DockBuilderSplitNode(
+    node_id: c.ImGuiID,
+    split_dir: c.ImGuiDir,
+    size_ratio_for_node_at_dir: f32,
+    out_id_at_dir: *c.ImGuiID,
+    out_id_at_opposite_dir: *c.ImGuiID,
+) c.ImGuiID;
+extern fn ImGui_DockBuilderDockWindow(window_name: [*c]const u8, node_id: c.ImGuiID) void;
+extern fn ImGui_DockBuilderFinish(node_id: c.ImGuiID) void;
+// ----------------------------------------------------------------------------
+
+pub fn draw_dockspace() void {
+    const viewport = c.ImGui_GetMainViewport();
+    c.ImGui_SetNextWindowPos(viewport.*.Pos, 0);
+    c.ImGui_SetNextWindowSize(viewport.*.Size, 0);
+    c.ImGui_SetNextWindowViewport(viewport.*.ID);
+
+    c.ImGui_PushStyleVarImVec2(c.ImGuiStyleVar_WindowPadding, .{ .x = 0.0, .y = 0.0 });
+    _ = c.ImGui_Begin(DOCKSPACE_WINDOW_NAME, null, c.ImGuiWindowFlags_NoTitleBar |
+        c.ImGuiWindowFlags_NoCollapse |
+        c.ImGuiWindowFlags_NoResize |
+        c.ImGuiWindowFlags_NoMove |
+        c.ImGuiWindowFlags_NoBringToFrontOnFocus |
+        c.ImGuiWindowFlags_NoNavFocus |
+        c.ImGuiWindowFlags_NoDocking);
+    defer c.ImGui_PopStyleVarEx(1);
+    defer c.ImGui_End();
+
+    const dockspace_id = c.ImGui_GetID(DOCKSPACE_ID);
+    // Only execute once at app startup.
+    if (ImGui_DockBuilderGetNode(dockspace_id) == null) {
+        build_default_layout(dockspace_id, viewport);
+    }
+
+    _ = c.ImGui_DockSpaceEx(
+        dockspace_id,
+        .{ .x = 0.0, .y = 0.0 },
+        PANE_DOCK_NODE_FLAGS,
+        null,
+    );
+}
+
+fn build_default_layout(dockspace_id: c.ImGuiID, viewport: *const c.ImGuiViewport) void {
+    ImGui_DockBuilderRemoveNode(dockspace_id);
+    _ = ImGui_DockBuilderAddNodeEx(
+        dockspace_id,
+        DOCK_NODE_FLAGS_DOCK_SPACE |
+            PANE_DOCK_NODE_FLAGS,
+    );
+    ImGui_DockBuilderSetNodePos(dockspace_id, viewport.Pos);
+    ImGui_DockBuilderSetNodeSize(dockspace_id, viewport.Size);
+
+    var left_id: c.ImGuiID = 0;
+    var right_id: c.ImGuiID = 0;
+    _ = ImGui_DockBuilderSplitNode(dockspace_id, c.ImGuiDir_Left, 0.24, &left_id, &right_id);
+
+    var video_id: c.ImGuiID = 0;
+    var bottom_id: c.ImGuiID = 0;
+    _ = ImGui_DockBuilderSplitNode(right_id, c.ImGuiDir_Down, 0.50, &bottom_id, &video_id);
+
+    ImGui_DockBuilderDockWindow(LEFT_WINDOW_NAME, left_id);
+    ImGui_DockBuilderDockWindow(VIDEO_WINDOW_NAME, video_id);
+    ImGui_DockBuilderDockWindow(BOTTOM_WINDOW_NAME, bottom_id);
+    ImGui_DockBuilderFinish(dockspace_id);
+}

--- a/src/ui/draw_bottom_panel.zig
+++ b/src/ui/draw_bottom_panel.zig
@@ -1,0 +1,7 @@
+const c = @import("imguiz").imguiz;
+const dockspace = @import("./dockspace.zig");
+
+pub fn draw_bottom_panel() void {
+    _ = c.ImGui_Begin(dockspace.BOTTOM_WINDOW_NAME, null, c.ImGuiWindowFlags_None);
+    defer c.ImGui_End();
+}

--- a/src/ui/draw_left_column.zig
+++ b/src/ui/draw_left_column.zig
@@ -6,8 +6,8 @@ const AUDIO_GAIN_MAX = @import("../store/capture_store.zig").AUDIO_GAIN_MAX;
 const imgui_util = @import("./imgui_util.zig");
 const util = @import("../util.zig");
 const Store = @import("../store/store.zig").Store;
+const dockspace = @import("./dockspace.zig");
 
-pub const COLUMN_WIDTH = 380;
 const CONTROL_HEIGHT: f32 = 30;
 const GROUP_SPACING: f32 = 6;
 const GAIN_LABEL_WIDTH: f32 = 36.0;
@@ -168,21 +168,7 @@ fn draw_selected_audio_source_gain_sliders(allocator: std.mem.Allocator, store: 
 }
 
 pub fn draw_left_column(allocator: std.mem.Allocator, store: *Store, state: *Store.State) !void {
-    // Get viewport size
-    const viewport_pos = c.ImGui_GetMainViewport().*.Pos;
-    const viewport_size = c.ImGui_GetMainViewport().*.Size;
-
-    // Set position and size for the left panel window
-    c.ImGui_SetNextWindowPos(viewport_pos, 0);
-    c.ImGui_SetNextWindowSize(c.ImVec2{
-        .x = COLUMN_WIDTH,
-        .y = viewport_size.y,
-    }, 0);
-
-    _ = c.ImGui_Begin("left column", null, c.ImGuiWindowFlags_NoTitleBar |
-        c.ImGuiWindowFlags_NoResize |
-        c.ImGuiWindowFlags_NoMove |
-        c.ImGuiWindowFlags_NoCollapse);
+    _ = c.ImGui_Begin(dockspace.LEFT_WINDOW_NAME, null, c.ImGuiWindowFlags_None);
     defer c.ImGui_End();
 
     if (c.ImGui_BeginTabBar("MainTabBar", 0)) {
@@ -506,7 +492,9 @@ fn draw_capture_settings(allocator: std.mem.Allocator, store: *Store, state: *St
         c.ImGui_PopTextWrapPos();
     }
 
+    c.ImGui_PushTextWrapPos(0);
     c.ImGui_Text("Restore capture source on startup");
+    c.ImGui_PopTextWrapPos();
     c.ImGui_SameLine();
     imgui_util.help_marker("Try to restore the last capture source when Spacecap starts.");
     if (c.ImGui_Checkbox("##restore_capture_source_on_startup", &restore_capture_source_on_startup)) {
@@ -516,7 +504,9 @@ fn draw_capture_settings(allocator: std.mem.Allocator, store: *Store, state: *St
     }
 
     {
+        c.ImGui_PushTextWrapPos(0);
         c.ImGui_Text("Start replay buffer on startup");
+        c.ImGui_PopTextWrapPos();
         c.ImGui_SameLine();
         imgui_util.help_marker("Start the replay buffer when Spacecap starts. Requires 'Restore capture source on startup'.");
         c.ImGui_BeginDisabled(!restore_capture_source_on_startup);

--- a/src/ui/draw_video_preview.zig
+++ b/src/ui/draw_video_preview.zig
@@ -1,71 +1,70 @@
 const c = @import("imguiz").imguiz;
-const VulkanImageBuffer = @import("../vulkan/vulkan_image_buffer.zig").VulkanImageBuffer;
 const VulkanCapturePreviewTexture = @import("../vulkan/vulkan_capture_preview_texture.zig").VulkanCapturePreviewTexture;
-const COLUMN_WIDTH = @import("./draw_left_column.zig").COLUMN_WIDTH;
+const dockspace = @import("./dockspace.zig");
 
-pub fn draw_video_preview(args: union(enum) {
-    vulkan_video_not_supported,
-    capture_preview: struct {
-        capture_preview_buffer: *VulkanCapturePreviewTexture,
-        width: u32,
-        height: u32,
+pub fn draw_video_preview(
+    args: union(enum) {
+        // The empty state is for rendering a balck background even when
+        // a capture source isn't available.
+        empty,
+        vulkan_video_not_supported,
+        capture_preview: struct {
+            capture_preview_buffer: *VulkanCapturePreviewTexture,
+            width: u32,
+            height: u32,
+        },
     },
-}) !void {
-    const viewport_size = c.ImGui_GetMainViewport().*.Size;
-    const container_width = viewport_size.x - COLUMN_WIDTH;
-    const container_height = viewport_size.y * 0.7;
-    c.ImGui_SetNextWindowPos(.{ .x = COLUMN_WIDTH, .y = 0 }, 0);
-    c.ImGui_SetNextWindowSize(c.ImVec2{
-        .x = container_width,
-        .y = container_height,
-    }, 0);
+) !void {
     c.ImGui_PushStyleColor(c.ImGuiCol_WindowBg, c.IM_COL32(0, 0, 0, 255));
     c.ImGui_PushStyleVarImVec2(c.ImGuiStyleVar_WindowPadding, .{ .x = 0, .y = 0 });
     c.ImGui_PushStyleVar(c.ImGuiStyleVar_WindowBorderSize, 0);
-    _ = c.ImGui_Begin(
-        "video preview",
-        null,
-        c.ImGuiWindowFlags_NoTitleBar |
-            c.ImGuiWindowFlags_NoResize |
-            c.ImGuiWindowFlags_NoMouseInputs |
-            c.ImGuiWindowFlags_NoDecoration |
-            c.ImGuiWindowFlags_NoCollapse,
-    );
-    defer c.ImGui_PopStyleColor();
-    defer c.ImGui_PopStyleVarEx(2);
+
+    _ = c.ImGui_Begin(dockspace.VIDEO_WINDOW_NAME, null, c.ImGuiWindowFlags_None);
     defer c.ImGui_End();
 
-    if (args == .capture_preview) {
-        const capture_width = @as(f32, @floatFromInt(args.capture_preview.width));
-        const capture_height = @as(f32, @floatFromInt(args.capture_preview.height));
+    c.ImGui_PopStyleColor();
+    c.ImGui_PopStyleVarEx(2);
 
-        const aspect_ratio = capture_width / capture_height;
+    const container_size = c.ImGui_GetContentRegionAvail();
+    const container_width = container_size.x;
+    const container_height = container_size.y;
 
-        var render_width = container_width;
-        var render_height = render_width / aspect_ratio;
+    switch (args) {
+        .empty => {},
+        .capture_preview => |capture_preview| {
+            const capture_width: f32 = @floatFromInt(capture_preview.width);
+            const capture_height: f32 = @floatFromInt(capture_preview.height);
 
-        if (render_height > container_height) {
-            render_height = container_height;
-            render_width = render_height * aspect_ratio;
-        }
+            const aspect_ratio = capture_width / capture_height;
 
-        if (render_width > container_width) {
-            render_width = container_width;
-            render_height = render_width / aspect_ratio;
-        }
+            var render_width = container_width;
+            var render_height = render_width / aspect_ratio;
 
-        const cursor_x = (container_width - render_width) / 2;
-        c.ImGui_SetCursorPosX(cursor_x);
-        c.ImGui_Image(args.capture_preview.capture_preview_buffer.im_texture_ref, .{ .x = render_width, .y = render_height });
-    } else {
-        const message = "Vulkan video is not supported on your current hardware. Video recording will be disabled.";
-        const wrap_width = container_width * 0.8;
-        const text_size = c.ImGui_CalcTextSizeEx(message, null, false, wrap_width);
-        const cursor_x = (container_width - text_size.x) / 2;
-        const cursor_y = (container_height - text_size.y) / 2;
-        c.ImGui_SetCursorPos(.{ .x = cursor_x, .y = cursor_y });
-        c.ImGui_PushTextWrapPos(cursor_x + wrap_width);
-        c.ImGui_TextWrapped(message);
-        c.ImGui_PopTextWrapPos();
+            if (render_height > container_height) {
+                render_height = container_height;
+                render_width = render_height * aspect_ratio;
+            }
+
+            if (render_width > container_width) {
+                render_width = container_width;
+                render_height = render_width / aspect_ratio;
+            }
+
+            const cursor_x = (container_width - render_width) / 2;
+            const cursor_y = (container_height - render_height) / 2;
+            c.ImGui_SetCursorPos(.{ .x = cursor_x, .y = cursor_y });
+            c.ImGui_Image(capture_preview.capture_preview_buffer.im_texture_ref, .{ .x = render_width, .y = render_height });
+        },
+        .vulkan_video_not_supported => {
+            const message = "Vulkan video is not supported on your current hardware. Video recording will be disabled.";
+            const wrap_width = container_width * 0.8;
+            const text_size = c.ImGui_CalcTextSizeEx(message, null, false, wrap_width);
+            const cursor_x = (container_width - text_size.x) / 2;
+            const cursor_y = (container_height - text_size.y) / 2;
+            c.ImGui_SetCursorPos(.{ .x = cursor_x, .y = cursor_y });
+            c.ImGui_PushTextWrapPos(cursor_x + wrap_width);
+            c.ImGui_TextWrapped(message);
+            c.ImGui_PopTextWrapPos();
+        },
     }
 }

--- a/src/ui/ui.zig
+++ b/src/ui/ui.zig
@@ -9,12 +9,15 @@ const Arc = @import("../arc.zig").Arc;
 const VulkanCapturePreviewTexture = @import("../vulkan/vulkan_capture_preview_texture.zig").VulkanCapturePreviewTexture;
 const Vulkan = @import("../vulkan/vulkan.zig").Vulkan;
 const API_VERSION = @import("../vulkan/vulkan.zig").API_VERSION;
+const draw_dockspace = @import("./dockspace.zig").draw_dockspace;
 const draw_left_column = @import("./draw_left_column.zig").draw_left_column;
 const draw_video_preview = @import("./draw_video_preview.zig").draw_video_preview;
+const draw_bottom_panel = @import("./draw_bottom_panel.zig").draw_bottom_panel;
 const VulkanImageBuffer = @import("../vulkan/vulkan_image_buffer.zig").VulkanImageBuffer;
 const WaylandPresentGate = @import("./wayland_present_gate.zig").WaylandPresentGate;
 const AppIcon = @import("./app_icon.zig").AppIcon;
 const Store = @import("../store/store.zig").Store;
+const util = @import("../util.zig");
 
 // TODO: save and restore window size
 const WIDTH = 1600;
@@ -132,6 +135,7 @@ pub const UI = struct {
     descriptor_pool: ?vk.DescriptorPool = null,
     swapchain_rebuild: bool = false,
     wayland_present_gate: ?WaylandPresentGate = null,
+    imgui_ini_path: ?[:0]u8 = null,
     app_icon: AppIcon,
 
     /// Init SDL and return new UI instance.
@@ -175,8 +179,16 @@ pub const UI = struct {
         }
 
         self.app_icon.deinit();
+        if (self.imgui_ini_path) |imgui_ini_path| {
+            c.ImGui_SaveIniSettingsToDisk(imgui_ini_path.ptr);
+        }
         c.cImGui_ImplVulkan_Shutdown();
         c.cImGui_ImplSDL3_Shutdown();
+        c.ImGui_DestroyContext(null);
+        if (self.imgui_ini_path) |imgui_ini_path| {
+            // Must be freed after ImGui_DestroyContext.
+            self.allocator.free(imgui_ini_path);
+        }
         if (self.wayland_present_gate) |*wayland_present_gate| {
             wayland_present_gate.deinit();
         }
@@ -274,8 +286,22 @@ pub const UI = struct {
         const io = c.ImGui_GetIO();
         io.*.ConfigFlags |= c.ImGuiConfigFlags_NavEnableKeyboard; // Enable Keyboard Controls
         io.*.ConfigFlags |= c.ImGuiConfigFlags_NavEnableGamepad; // Enable Gamepad Controls
-        // io.*.ConfigFlags |= c.ImGuiConfigFlags_DockingEnable;
+        io.*.ConfigFlags |= c.ImGuiConfigFlags_DockingEnable;
         // io.*.ConfigFlags |= c.ImGuiConfigFlags_ViewportsEnable;
+
+        // ----------------------------------------------------------------------------
+        // Save the ImGui .ini config file in the Spacecap config directory.
+        // ----------------------------------------------------------------------------
+        const app_data_dir = try util.get_app_data_dir(self.allocator, self.io);
+        defer self.allocator.free(app_data_dir);
+        const imgui_ini_path = try std.fs.path.join(self.allocator, &.{ app_data_dir, "imgui.ini" });
+        defer self.allocator.free(imgui_ini_path);
+        self.imgui_ini_path = try self.allocator.dupeZ(u8, imgui_ini_path);
+        errdefer {
+            self.allocator.free(self.imgui_ini_path.?);
+            self.imgui_ini_path = null;
+        }
+        io.*.IniFilename = self.imgui_ini_path.?.ptr;
 
         // Setup Dear ImGui style
         setup_imgui_style();
@@ -485,6 +511,8 @@ pub const UI = struct {
                         }
                     }
 
+                    draw_dockspace();
+
                     try draw_left_column(self.allocator, self.store, state);
 
                     if (!state.capture.is_video_capture_supprted) {
@@ -503,7 +531,11 @@ pub const UI = struct {
                                 } });
                             }
                         }
+                    } else {
+                        try draw_video_preview(.empty);
                     }
+
+                    draw_bottom_panel();
                 }
 
                 // Rendering while preview locks are held.


### PR DESCRIPTION
Save the imgui.ini file to the Spacecap config directory.

Use the ImGui dock builder to create resizable panes for the application:

- Left pane.
  - Used for settings and eventually file browser etc.
- Top right pane.
  - Video capture preview.
- Bottom right pane.
  - TODO: Will show capture source, replay/record buttons, audio devices etc. They will be moved from the left pane.