### PR TITLE
build: switch from ReleaseFast to ReleaseSafe

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,4 +41,4 @@ jobs:
         run: nix develop -c zig build test -Dnix
 
       - name: Build AppImage
-        run: nix develop -c zig build -Dappimage -Doptimize=ReleaseFast
+        run: nix develop -c zig build -Dappimage -Doptimize=ReleaseSafe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           echo "release_version=${release_version}" >> "$GITHUB_OUTPUT"
 
       - name: Build Release Binaries
-        run: nix develop -c zig build ${{ steps.version.outputs.release_build_args }} -Dappimage -Doptimize=ReleaseFast
+        run: nix develop -c zig build ${{ steps.version.outputs.release_build_args }} -Dappimage -Doptimize=ReleaseSafe
 
       # - name: Package Linux
       #   run: tar -czf spacecap-linux-x86_64.tar.gz -C zig-out linux

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-<h1 align="center">Spacecap</h1>
 <p align="center">
     <img align="center" src="./packaging/logo_blue.png"/>
 </p>
+<h1 align="center">Spacecap</h1>
 
 A hardware accelerated screen recording/replay application focused on performance.
 Currently only supports Linux. Still in early development (see roadmap below).
@@ -84,3 +84,21 @@ nix develop -c zig build run -Dnix
 # Test
 nix develop -c zig build test -Dnix
 ```
+
+### Logging
+
+By default, Spacecap only writes error logs to `error.log`. Set the
+`SPACECAP_LOG_LEVEL` environment variable to one of the following to change this
+behavior:
+
+- debug
+- info
+- warning
+- error
+
+Crash logs are written to `crash.log`. This happens when a panic occurs.
+
+#### Log Location
+
+- **Linux**: `$XDG_CONFIG_HOME/spacecap`, or `$HOME/.config/spacecap`
+- **Windows**: `%APPDATA%\spacecap`.

--- a/build.zig
+++ b/build.zig
@@ -63,6 +63,11 @@ fn add_shared_dependencies(
         .optimize = optimize,
         .freetype = true,
     }).module("imguiz");
+    if (target.result.os.tag == .windows) {
+        // MinGW fortify emits inline wcscat_s/wcscpy_s wrappers that Zig 0.16
+        // currently translates with unused local constants in ReleaseSafe.
+        imguiz.addCMacro("_FORTIFY_SOURCE", "0");
+    }
     exe.root_module.addImport("imguiz", imguiz);
 
     // zig-clap
@@ -167,6 +172,8 @@ fn build_windows(
         .optimize = optimize,
         .link_libc = true,
     });
+    // See comment above where this macro is added.
+    module.addCMacro("_FORTIFY_SOURCE", "0");
     module.addOptions("build_options", options);
 
     const exe = b.addExecutable(.{
@@ -351,7 +358,7 @@ pub fn build(b: *std.Build) !void {
 
     const optimize = b.standardOptimizeOption(.{});
     if (appimage_option and optimize == .Debug) {
-        std.log.err("AppImage builds require a release optimize mode. Use -Doptimize=ReleaseFast, -Doptimize=ReleaseSafe, or -Doptimize=ReleaseSmall.", .{});
+        std.log.err("AppImage builds require a release optimize mode. Use -Doptimize=ReleaseSafe, -Doptimize=ReleaseFast, or -Doptimize=ReleaseSmall.", .{});
         return error.InvalidBuildConfig;
     }
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -85,13 +85,13 @@
             .url = "https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n8.0.1.tar.gz",
             .hash = "N-V-__8AAH4RHQXHEafp_hkUel3EMeK1wjHBfaIYYxYsKdiM",
         },
-        .pipewire = .{
-            .url = "https://github.com/mgerb/pipewire/archive/refs/heads/zig-0.16.0.tar.gz",
-            .hash = "pipewire-1.6.3-tKslQ_-KAQBG5PNtHtIRFe7BbdJBHKamvj_ySBC1TDFE",
-        },
         .clap = .{
             .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.12.0.tar.gz",
             .hash = "clap-0.12.0-oBajB7foAQDqlSwaSG5g0yq7xGbQARUsBk5T64gAOqP5",
+        },
+        .pipewire = .{
+            .url = "git+https://github.com/mgerb/pipewire#80b7f695e14d2726ba59f2ad03cbc7cdd6066d12",
+            .hash = "pipewire-1.6.3-tKslQ1aLAQAzbaWMWTqfvQKzzUaKx34CBpE6hWT4HRNY",
         },
     },
 

--- a/src/args.zig
+++ b/src/args.zig
@@ -50,14 +50,13 @@ pub fn parse(init: std.process.Init) ?Args {
     } else if (comptime Util.is_windows()) {
         return parse_windows(init);
     } else {
-        log.err("unsupported platform", .{});
-        unreachable;
+        @compileError("unsupported platform");
     }
 }
 
 fn print_version(io: std.Io) void {
     var stdout = std.Io.File.stdout().writer(io, &.{});
-    stdout.interface.print("{s}\n", .{build_options.version}) catch unreachable;
+    stdout.interface.print("{s}\n", .{build_options.version}) catch @panic("print_version error");
 }
 
 fn parse_linux(init: std.process.Init) ?Args {

--- a/src/capture/audio/linux/audio_devices.zig
+++ b/src/capture/audio/linux/audio_devices.zig
@@ -216,7 +216,9 @@ fn on_registry_global(
         .node_name = node_name_copy,
         .node_desc = node_desc_copy,
     };
-    list_data.devices.append(allocator, device) catch unreachable;
+    list_data.devices.append(allocator, device) catch |err| {
+        log.err("[on_registry_global] list_data.devices.append error: {}", .{err});
+    };
 }
 
 fn name_matches(name: ?[]const u8, node_name: []const u8) bool {
@@ -252,7 +254,9 @@ fn on_metadata_property(
     }
 
     const value_slice = std.mem.span(value);
-    list_data.set_default(key_slice, value_slice) catch unreachable;
+    list_data.set_default(key_slice, value_slice) catch |err| {
+        log.err("[on_metadata_property] list_data.set_default error: {}", .{err});
+    };
     return 0;
 }
 

--- a/src/capture/video/linux/pipewire/pipewire_frame_buffer_manager.zig
+++ b/src/capture/video/linux/pipewire/pipewire_frame_buffer_manager.zig
@@ -188,7 +188,8 @@ pub const PipewireFrameBufferManager = struct {
 
         var import_fd_info = vk.ImportMemoryFdInfoKHR{
             .handle_type = .{ .dma_buf_bit_ext = true },
-            .fd = c.fcntl(@intCast(fd), c.F_DUPFD_CLOEXEC, @as(u32, 0)),
+            // TODO: This could error (-1). We should probably handle this scenario.
+            .fd = @intCast(std.os.linux.fcntl(@intCast(fd), std.os.linux.F.DUPFD_CLOEXEC, 0)),
         };
 
         // NOTE: This is critical for Nvidia cards. Causes buffer to be empty without it.

--- a/src/capture/video/linux/pipewire/pipewire_video.zig
+++ b/src/capture/video/linux/pipewire/pipewire_video.zig
@@ -627,7 +627,10 @@ pub const PipewireVideo = struct {
                 "i",
                 @as(i32, @intCast(@sizeOf(pw.spa_meta_header))),
             },
-        )))) catch unreachable;
+        )))) catch |err| {
+            log.err("[send_stream_params] spa_pod_params.params.append error: {}", .{err});
+            return;
+        };
 
         // damage
         spa_pod_params.params.append(self.allocator, @ptrCast(@alignCast(c_def.spa_pod_builder_add_object(
@@ -645,7 +648,10 @@ pub const PipewireVideo = struct {
                 @as(i32, @sizeOf(pw.spa_meta_region) * 1),
                 @as(i32, @sizeOf(pw.spa_meta_region) * 16),
             },
-        )))) catch unreachable;
+        )))) catch |err| {
+            log.err("[send_stream_params] spa_pod_params.params.append error: {}", .{err});
+            return;
+        };
 
         // cursor
         spa_pod_params.params.append(self.allocator, @ptrCast(@alignCast(c_def.spa_pod_builder_add_object(
@@ -663,13 +669,19 @@ pub const PipewireVideo = struct {
                 @as(i32, @sizeOf(pw.spa_meta_cursor) + @sizeOf(pw.spa_meta_bitmap) + 1 + 1 * 4),
                 @as(i32, @sizeOf(pw.spa_meta_cursor) + @sizeOf(pw.spa_meta_bitmap) + 1024 + 1024 * 4),
             },
-        )))) catch unreachable;
+        )))) catch |err| {
+            log.err("[send_stream_params] spa_pod_params.params.append error: {}", .{err});
+            return;
+        };
 
         spa_pod_params.params.append(self.allocator, @ptrCast(@alignCast(c_def.spa_pod_builder_add_object(&builder, pw.SPA_TYPE_OBJECT_ParamBuffers, pw.SPA_PARAM_Buffers, .{
             pw.SPA_PARAM_BUFFERS_dataType,
             "i",
             @as(i32, 1 << pw.SPA_DATA_DmaBuf),
-        })))) catch unreachable;
+        })))) catch |err| {
+            log.err("[send_stream_params] spa_pod_params.params.append error: {}", .{err});
+            return;
+        };
 
         _ = pw.pw_stream_update_params(
             self.stream,

--- a/src/capture/video/windows/windows_video_capture.zig
+++ b/src/capture/video/windows/windows_video_capture.zig
@@ -108,11 +108,11 @@ pub fn windows_capture(allocator: std.mem.Allocator) ![]u8 {
     const width: i32 = c.GetSystemMetrics(c.SM_CXSCREEN);
     const height: i32 = c.GetSystemMetrics(c.SM_CYSCREEN);
 
-    const hScreenDC: c.HDC = c.GetDC(null) orelse unreachable;
+    const hScreenDC: c.HDC = c.GetDC(null) orelse @panic("c.GetDC error");
     defer _ = c.DeleteObject(@ptrCast(hScreenDC));
     const hMemoryDC: c.HDC = c.CreateCompatibleDC(hScreenDC);
     defer _ = c.DeleteObject(@ptrCast(hMemoryDC));
-    const hBitmap: c.HBITMAP = c.CreateCompatibleBitmap(hScreenDC, width, height) orelse unreachable;
+    const hBitmap: c.HBITMAP = c.CreateCompatibleBitmap(hScreenDC, width, height) orelse @panic("c.CreateCompatibleBitmap error");
     defer _ = c.DeleteObject(hBitmap);
 
     _ = c.SelectObject(hMemoryDC, hBitmap);

--- a/src/common/linux/pipewire_include.zig
+++ b/src/common/linux/pipewire_include.zig
@@ -4,7 +4,6 @@ const pw = @import("pipewire").c;
 pub const c = @cImport({
     @cInclude("sys/mman.h");
     @cInclude("sys/ioctl.h");
-    @cInclude("fcntl.h");
     @cInclude("linux/dma-buf.h");
 });
 

--- a/src/env.zig
+++ b/src/env.zig
@@ -1,16 +1,20 @@
 const std = @import("std");
 const Mutex = @import("./mutex.zig").Mutex;
 
+// NOTE: All application env variables should be defined here.
+pub const SPACECAP_LOG_LEVEL = "SPACECAP_LOG_LEVEL";
+
+/// Thread safe global environment map.
 pub var ENVIRON_MAP: Mutex(*std.process.Environ.Map) = undefined;
 
 pub fn init(io: std.Io, environ_map: *std.process.Environ.Map) void {
     ENVIRON_MAP = .init(io, environ_map);
 }
 
-pub fn get_env_var_owned(allocator: std.mem.Allocator, key: []const u8) ![]u8 {
+pub fn get_env_var_owned(allocator: std.mem.Allocator, key: []const u8) ?[]u8 {
     const env_map_locked = ENVIRON_MAP.lock();
     defer env_map_locked.unlock();
 
-    const value = env_map_locked.unwrap().get(key) orelse return error.EnvironmentVariableNotFound;
-    return allocator.dupe(u8, value);
+    const value = env_map_locked.unwrap().get(key) orelse return null;
+    return allocator.dupe(u8, value) catch null;
 }

--- a/src/global_shortcuts/linux/xdg_desktop_portal_global_shortcuts.zig
+++ b/src/global_shortcuts/linux/xdg_desktop_portal_global_shortcuts.zig
@@ -199,7 +199,7 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
         const self: *Self = @ptrCast(@alignCast(args));
         // NOTE: This is not implemented in most xdg desktop portal implementations yet.
         // We'll revisit this later.
-        self.configure_shortcuts() catch unreachable;
+        self.configure_shortcuts();
         return 0;
     }
 
@@ -207,8 +207,8 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
     // It currently does not work in my KDE Plasma 6 desktop environment. Need to revisit
     // this later.
     // https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.impl.portal.GlobalShortcuts.html#org-freedesktop-impl-portal-globalshortcuts-configureshortcuts
-    fn configure_shortcuts(self: *Self) !void {
-        const handle = self.handle orelse return error.NoSession;
+    fn configure_shortcuts(self: *Self) void {
+        const handle = self.handle orelse @panic("handle should never be null");
 
         // TODO: Need to figure out how to get the activation token;
         const activation_token = "todo";
@@ -294,12 +294,21 @@ pub const XdgDesktopPortalGlobalShortcuts = struct {
                 // See https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GlobalShortcuts.html#org-freedesktop-portal-globalshortcuts-createsession
                 .create_session => {
                     if (self.create_session.restore_session) {
-                        shortcuts.session_token = TokenStorage.load_token_z(shortcuts.allocator, shortcuts.io, "session_token") catch unreachable;
+                        shortcuts.session_token = TokenStorage.load_token_z(shortcuts.allocator, shortcuts.io, "session_token") catch |err| {
+                            log.err("[make_payload] TokenStorage.load_token_z error: {}", .{err});
+                            return null;
+                        };
                     }
 
                     if (shortcuts.session_token == null) {
-                        shortcuts.session_token = @constCast(TokenManager.generate_token(shortcuts.allocator, shortcuts.io) catch unreachable);
-                        TokenStorage.save_token(shortcuts.allocator, shortcuts.io, "session_token", shortcuts.session_token.?) catch unreachable;
+                        shortcuts.session_token = @constCast(TokenManager.generate_token(shortcuts.allocator, shortcuts.io) catch |err| {
+                            log.err("[make_payload] TokenStorage.generate_token error: {}", .{err});
+                            return null;
+                        });
+                        TokenStorage.save_token(shortcuts.allocator, shortcuts.io, "session_token", shortcuts.session_token.?) catch |err| {
+                            log.err("[make_payload] TokenStorage.save_token error: {}", .{err});
+                            return null;
+                        };
                     }
 
                     assert(shortcuts.session_token != null);

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -1,0 +1,270 @@
+//! This module handles all logging for Spacecap. There is one instance of a
+//! logger (LOGGER), which handles stdout/stderr (std.log.defaultLog) and file
+//! logging. By default, only error logs get written to a file, however this
+//! can be changed by the SPACECAP_LOG_LEVEL environment variable.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Env = @import("./env.zig");
+const Util = @import("./util.zig");
+const BufferedChan = @import("./channel.zig").BufferedChan;
+
+const CRASH_LOG_FILE_NAME = "crash.log";
+
+/// Singleton instance of LoggerInternal.
+var LOGGER: ?LoggerInternal = null;
+
+/// Initialize the singleton instance of LoggerInternal.
+pub fn init(allocator: Allocator, io: std.Io) Allocator.Error!void {
+    LOGGER = try .init(allocator, io);
+}
+
+/// Deinit the singleton instance of LoggerInternal.
+pub fn deinit() void {
+    if (LOGGER) |*logger| {
+        logger.deinit();
+    }
+}
+
+/// Global log handler. Will call std.log.defaultLog if the global logger has
+/// not been initialized yet.
+pub fn logFn(
+    comptime level: std.log.Level,
+    comptime scope: @EnumLiteral(),
+    comptime format: []const u8,
+    log_args: anytype,
+) void {
+    if (LOGGER) |*logger| {
+        logger.log(level, scope, format, log_args) catch {
+            // NOTE: Do nothing here. We can't log because we don't want to get
+            // stuck in an infinite loop.
+        };
+    } else {
+        std.log.defaultLog(level, scope, format, log_args);
+    }
+}
+
+pub fn panicFn(msg: []const u8, first_trace_addr: ?usize) noreturn {
+    if (LOGGER) |*logger| {
+        logger.write_panic(msg, first_trace_addr) catch |err| {
+            std.debug.print("[panicFn] failed to write crash log: {}\n", .{err});
+        };
+    }
+    std.debug.defaultPanic(msg, first_trace_addr);
+}
+
+const LoggerInternal = struct {
+    const Self = @This();
+
+    allocator: Allocator,
+    io: std.Io,
+    console_log_level: std.log.Level,
+    file_log_level: std.log.Level,
+    crash_log_path: []const u8,
+    log_path: []const u8,
+    io_group: std.Io.Group = .init,
+    log_chan: BufferedChan([]const u8, 1000),
+    log_write_mutex: std.Io.Mutex = .init,
+
+    pub fn init(allocator: Allocator, io: std.Io) Allocator.Error!Self {
+        const data_dir = try Util.get_app_data_dir(allocator, io);
+        defer allocator.free(data_dir);
+
+        const env_var = Env.get_env_var_owned(allocator, Env.SPACECAP_LOG_LEVEL);
+        defer if (env_var) |val| allocator.free(val);
+
+        const user_provided_log_level = read_log_level(env_var);
+        const console_log_level = user_provided_log_level orelse std.log.default_level;
+        const file_log_level = user_provided_log_level orelse .err;
+
+        const crash_log_path = try std.fs.path.join(allocator, &.{ data_dir, CRASH_LOG_FILE_NAME });
+        errdefer allocator.free(crash_log_path);
+
+        const log_path = try std.fs.path.join(allocator, &.{ data_dir, log_file_name(file_log_level) });
+        errdefer allocator.free(log_path);
+
+        return .{
+            .allocator = allocator,
+            .io = io,
+            .crash_log_path = crash_log_path,
+            .console_log_level = console_log_level,
+            .file_log_level = file_log_level,
+            .log_path = log_path,
+            .log_chan = try .init(allocator, io),
+        };
+    }
+
+    pub fn deinit(self: *Self) void {
+        self.io_group.await(self.io) catch {
+            // No sense in logging here since it'll end up using this wait group.
+            @panic("self.io_group.await error.");
+        };
+        self.log_chan.deinit();
+        self.allocator.free(self.crash_log_path);
+        self.allocator.free(self.log_path);
+    }
+
+    pub fn log(
+        self: *Self,
+        comptime level: std.log.Level,
+        comptime scope: @EnumLiteral(),
+        comptime format: []const u8,
+        args: anytype,
+    ) !void {
+        if (@intFromEnum(self.console_log_level) >= @intFromEnum(level)) {
+            std.log.defaultLog(level, scope, format, args);
+        }
+
+        if (@intFromEnum(self.file_log_level) >= @intFromEnum(level)) {
+            try self.write_log(level, scope, format, args);
+        }
+    }
+
+    /// Queues up messages and writes to the log file asynchronously. This must
+    /// not block! If the queue is full, messages will be discarded. This is
+    /// thread safe.
+    fn write_log(
+        self: *Self,
+        comptime level: std.log.Level,
+        comptime scope: @EnumLiteral(),
+        comptime format: []const u8,
+        args: anytype,
+    ) !void {
+        const timestamp = Util.format_timestamp_utc(std.Io.Timestamp.now(self.io, .real).toMilliseconds());
+        const message = blk: {
+            if (scope != .default) {
+                break :blk try std.fmt.allocPrint(self.allocator, "[{s}] {s}({t}): " ++ format ++ "\n", .{ &timestamp, log_level_label(level), scope } ++ args);
+            }
+            break :blk try std.fmt.allocPrint(self.allocator, "[{s}] {s}: " ++ format ++ "\n", .{ &timestamp, log_level_label(level) } ++ args);
+        };
+        errdefer self.allocator.free(message);
+
+        // We must use a queue so that logs get written in order.
+        if (!try self.log_chan.try_send(message)) {
+            self.allocator.free(message);
+        }
+
+        self.io_group.async(self.io, struct {
+            fn run(_self: *Self) void {
+                write_log_async(_self) catch {
+                    // WARNING: This will fail silently. We can't really do anything
+                    // here because logging a write failure could cause an endless loop.
+                };
+            }
+        }.run, .{self});
+    }
+
+    /// This function executes asynchronously. Lock so that multiple handlers
+    /// don't write logs out of order to a file.
+    fn write_log_async(self: *Self) !void {
+        self.log_write_mutex.lockUncancelable(self.io);
+        defer self.log_write_mutex.unlock(self.io);
+
+        var writer_buffer: [4096]u8 = undefined;
+        const file = try std.Io.Dir.createFileAbsolute(self.io, self.log_path, .{ .truncate = false });
+        defer file.close(self.io);
+
+        var writer = file.writer(self.io, &writer_buffer);
+        try writer.seekTo(try file.length(self.io));
+        while (try self.log_chan.try_recv()) |message| {
+            defer self.allocator.free(message);
+
+            try writer.interface.writeAll(message);
+        }
+        try writer.flush();
+        try file.sync(self.io);
+    }
+
+    // NOTE: There should be no allocations in here.
+    pub fn write_panic(self: *Self, msg: []const u8, first_trace_addr: ?usize) !void {
+        const file = try std.Io.Dir.createFileAbsolute(self.io, self.crash_log_path, .{ .truncate = false });
+        defer file.close(self.io);
+
+        var offset = try file.length(self.io);
+        var buffer: [512]u8 = undefined;
+        var trace_buffer: [4096]u8 = undefined;
+
+        const timestamp = Util.format_timestamp_utc(std.Io.Timestamp.now(self.io, .real).toMilliseconds());
+        const header = if (first_trace_addr) |addr|
+            try std.fmt.bufPrint(
+                &buffer,
+                \\----------------------------------------------------------------------------
+                \\  PANIC: {s}
+                \\  address: 0x{x}
+                \\  message: 
+            ,
+                .{ &timestamp, addr },
+            )
+        else
+            try std.fmt.bufPrint(
+                &buffer,
+                \\----------------------------------------------------------------------------
+                \\  PANIC: {s}
+                \\  message: 
+            ,
+                .{&timestamp},
+            );
+
+        try file.writePositionalAll(self.io, header, offset);
+        offset += header.len;
+        try file.writePositionalAll(self.io, msg, offset);
+        offset += msg.len;
+        try file.writePositionalAll(self.io, "\n", offset);
+        offset += 1;
+
+        var writer = file.writer(self.io, &trace_buffer);
+        try writer.seekTo(offset);
+        const terminal = std.Io.Terminal{
+            .writer = &writer.interface,
+            .mode = .no_color,
+        };
+
+        try writer.interface.writeAll(
+            \\  stack trace:
+            \\
+            \\
+        );
+        try std.debug.writeCurrentStackTrace(.{
+            .first_address = first_trace_addr orelse @returnAddress(),
+            .allow_unsafe_unwind = true,
+        }, terminal);
+        try writer.interface.writeAll(
+            \\----------------------------------------------------------------------------
+            \\
+            \\
+        );
+        try writer.flush();
+
+        try file.sync(self.io);
+    }
+
+    /// Read the log level from user input.
+    fn read_log_level(spacecap_log_level: ?[]const u8) ?std.log.Level {
+        if (spacecap_log_level) |log_level| {
+            const trimmed = std.mem.trim(u8, log_level, &std.ascii.whitespace);
+            if (std.ascii.eqlIgnoreCase(trimmed, "debug")) return .debug;
+            if (std.ascii.eqlIgnoreCase(trimmed, "info")) return .info;
+            if (std.ascii.eqlIgnoreCase(trimmed, "warning")) return .warn;
+            if (std.ascii.eqlIgnoreCase(trimmed, "error")) return .err;
+        }
+        return null;
+    }
+
+    fn log_file_name(level: std.log.Level) []const u8 {
+        return switch (level) {
+            .err => "error.log",
+            .warn => "warn.log",
+            .info => "info.log",
+            .debug => "debug.log",
+        };
+    }
+
+    fn log_level_label(comptime level: std.log.Level) []const u8 {
+        return switch (level) {
+            .err => "error",
+            .warn => "warn",
+            .info => "info",
+            .debug => "debug",
+        };
+    }
+};

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,13 +14,32 @@ const Store = @import("./store/store.zig").Store;
 const ipc_module = @import("./ipc/ipc.zig");
 const IpcCommand = ipc_module.IpcCommand;
 const Env = @import("./env.zig");
+const Logger = @import("./logger.zig");
 
 const log = std.log.scoped(.main);
 
+// ----------------------------------------------------------------------------
+// Configure logging.
+// ----------------------------------------------------------------------------
+pub const std_options = std.Options{
+    .log_level = .debug,
+    .logFn = Logger.logFn,
+};
+pub const panic = std.debug.FullPanic(Logger.panicFn);
+
+/// ----------------------------------------------------------------------------
+/// Main entrypoint.
+/// ----------------------------------------------------------------------------
 pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
 
+    // NOTE: Must be initialized before the logger.
     Env.init(init.io, init.environ_map);
+
+    try Logger.init(allocator, init.io);
+    // NOTE: Any calls to the logger before this point will be handled by the
+    // default logger. This includes logger invocations within Logger.init.
+    defer Logger.deinit();
 
     const parsed_args: ?args.Args = args.parse(init);
 

--- a/src/store/video_session.zig
+++ b/src/store/video_session.zig
@@ -286,8 +286,6 @@ pub const VideoSession = struct {
             const next_projected_frame_start_time = previous_frame_start_time + @as(u64, @intFromFloat(ns_per_frame));
 
             if (previous_frame_start_time > 0 and next_projected_frame_start_time > now) {
-                // TODO: add to state
-                Util.print_elapsed(self.io, previous_frame_start_time, "previous_frame_start_time");
                 try std.Io.sleep(self.store.io, .fromNanoseconds(@intCast(next_projected_frame_start_time - now)), .awake);
             }
 

--- a/src/util.zig
+++ b/src/util.zig
@@ -17,7 +17,7 @@ pub fn is_linux() bool {
 pub fn print_elapsed(io: std.Io, start_time: i128, prefix: []const u8) void {
     const end: i128 = @intCast(std.Io.Clock.real.now(io).nanoseconds);
     const total_time = @divFloor(end - start_time, @as(i128, @intCast(std.time.ns_per_ms)));
-    std.debug.print("[{s}] time elapsed {}ms\n", .{ prefix, total_time });
+    log.debug("[{s}] time elapsed {}ms\n", .{ prefix, total_time });
 }
 
 pub fn format_duration_label(allocator: std.mem.Allocator, total_seconds: u32) ![:0]u8 {
@@ -44,6 +44,31 @@ pub fn format_duration_label(allocator: std.mem.Allocator, total_seconds: u32) !
         return std.fmt.allocPrintSentinel(allocator, "{d}m", .{minutes}, 0);
     }
     return std.fmt.allocPrintSentinel(allocator, "{d}s", .{seconds}, 0);
+}
+
+const TimestampString = [27]u8;
+pub fn format_timestamp_utc(timestamp_ms: i64) TimestampString {
+    const epoch_ms: u64 = @intCast(@max(timestamp_ms, 0));
+    const epoch_seconds = std.time.epoch.EpochSeconds{ .secs = epoch_ms / std.time.ms_per_s };
+    const year_day = epoch_seconds.getEpochDay().calculateYearDay();
+    const month_day = year_day.calculateMonthDay();
+    const day_seconds = epoch_seconds.getDaySeconds();
+
+    var buffer: TimestampString = undefined;
+    _ = std.fmt.bufPrint(
+        &buffer,
+        "{d:0>4}-{d:0>2}-{d:0>2} {d:0>2}:{d:0>2}:{d:0>2}.{d:0>3} UTC",
+        .{
+            year_day.year,
+            month_day.month.numeric(),
+            month_day.day_index + 1,
+            day_seconds.getHoursIntoDay(),
+            day_seconds.getMinutesIntoHour(),
+            day_seconds.getSecondsIntoMinute(),
+            epoch_ms % std.time.ms_per_s,
+        },
+    ) catch @panic("std.fmt.bufPrint error");
+    return buffer;
 }
 
 /// Write bgrx data to a .bmp file - used for testing
@@ -129,7 +154,7 @@ pub fn check_fd(fd: i64) !void {
 /// - Linux: $XDG_CONFIG_HOME/spacecap or $HOME/.config/spacecap
 /// The returned path is owned by the caller and must be freed.
 /// This function will create the directory if it does not exist.
-pub fn get_app_data_dir(allocator: std.mem.Allocator, io: std.Io) ![]u8 {
+pub fn get_app_data_dir(allocator: std.mem.Allocator, io: std.Io) std.mem.Allocator.Error![]u8 {
     if (@import("builtin").is_test) {
         const TEST_APP_DATA_DIR = @import("./test.zig").TEST_APP_DATA_DIR;
         // NOTE: See test.zig for usage.
@@ -138,9 +163,9 @@ pub fn get_app_data_dir(allocator: std.mem.Allocator, io: std.Io) ![]u8 {
     }
 
     // TODO: Test on Windows.
-    const base_dir: []u8 = if (comptime is_windows()) blk: {
+    const base_dir: ?[]u8 = if (comptime is_windows()) blk: {
         // On Windows, use %APPDATA%
-        break :blk try Env.get_env_var_owned(allocator, "APPDATA");
+        break :blk Env.get_env_var_owned(allocator, "APPDATA");
     } else if (comptime is_linux()) blk: {
         // On Linux, use $XDG_CONFIG_HOME or $HOME/.config
         if (Env.get_env_var_owned(allocator, "XDG_CONFIG_HOME")) |xdg_config_home| {
@@ -148,25 +173,34 @@ pub fn get_app_data_dir(allocator: std.mem.Allocator, io: std.Io) ![]u8 {
                 break :blk xdg_config_home;
             }
             allocator.free(xdg_config_home);
-        } else |err| switch (err) {
-            error.EnvironmentVariableNotFound => {},
-            else => return err,
         }
 
-        const home = try Env.get_env_var_owned(allocator, "HOME");
+        const home = Env.get_env_var_owned(allocator, "HOME") orelse break :blk null;
         defer allocator.free(home);
         break :blk try std.fs.path.join(allocator, &.{ home, ".config" });
     } else {
         @compileError("Unsupported OS");
     };
-    defer allocator.free(base_dir);
 
-    const app_config_dir = try std.fs.path.join(allocator, &.{ base_dir, "spacecap" });
-    errdefer allocator.free(app_config_dir);
+    if (base_dir) |_base_dir| {
+        defer allocator.free(_base_dir);
 
-    try std.Io.Dir.cwd().createDirPath(io, app_config_dir);
+        const app_config_dir = try std.fs.path.join(allocator, &.{ _base_dir, "spacecap" });
+        errdefer allocator.free(app_config_dir);
 
-    return app_config_dir;
+        if (std.Io.Dir.cwd().createDirPath(io, app_config_dir)) {
+            return app_config_dir;
+        } else |err| {
+            log.err("[get_app_data_dir] failed to create app data directory {s}: {}", .{ app_config_dir, err });
+            allocator.free(app_config_dir);
+        }
+    }
+
+    log.warn("[get_app_data_dir] falling back to current working directory", .{});
+    return std.process.currentPathAlloc(io, allocator) catch |err| {
+        log.err("[get_app_data_dir] failed to get current working directory: {}", .{err});
+        return allocator.dupe(u8, ".");
+    };
 }
 
 // Falls back to the current working directory when
@@ -183,18 +217,12 @@ pub fn get_default_video_output_dir(allocator: std.mem.Allocator, io: std.Io) ![
 
     // TODO: Test on Windows.
     const home_dir: ?[]u8 = if (comptime is_windows()) blk: {
-        break :blk Env.get_env_var_owned(allocator, "USERPROFILE") catch |err| {
-            log.err("[get_default_video_output_dir] failed to read USERPROFILE: {}", .{err});
-            break :blk Env.get_env_var_owned(allocator, "HOME") catch |home_err| {
-                log.err("[get_default_video_output_dir] failed to read HOME: {}", .{home_err});
-                break :blk null;
-            };
-        };
+        if (Env.get_env_var_owned(allocator, "USERPROFILE")) |user_profile| {
+            break :blk user_profile;
+        }
+        break :blk Env.get_env_var_owned(allocator, "HOME");
     } else if (comptime is_linux()) blk: {
-        break :blk Env.get_env_var_owned(allocator, "HOME") catch |err| {
-            log.err("[get_default_video_output_dir] failed to read HOME: {}", .{err});
-            break :blk null;
-        };
+        break :blk Env.get_env_var_owned(allocator, "HOME");
     } else {
         @compileError("Unsupported OS");
     };

--- a/src/video/video_replay_buffer.zig
+++ b/src/video/video_replay_buffer.zig
@@ -103,7 +103,7 @@ pub const VideoReplayBuffer = struct {
 
                 if (first_node != last_node) {
                     const total_time = last_node.data.timestamp_ns - first_node.data.timestamp_ns;
-                    const total_seconds: u32 = @intCast(std.math.divCeil(i128, total_time, std.time.ns_per_s) catch unreachable);
+                    const total_seconds: u32 = @intCast(std.math.divCeil(i128, total_time, std.time.ns_per_s) catch @panic("divCeil error"));
                     return total_seconds;
                 }
             }


### PR DESCRIPTION
- This switch is so that we can collect crash logs and more easily diagnose issues if anybody starts using this. So far the performance hit seems negligible, but I haven't done a ton of testing yet. At some point in the future we can probably ship a ReleaseFast binary.
- Add a panic log handler so that we can collect crash logs.
- Add error file log handler.
- The ReleaseSafe build was currently broken. It relied on a change to the pipewire dependency. Also removed reliance on `fcntl.h` by switching to the zig std.
- Remove all `unreachable` as it is undefined behavior in ReleaseSafe.

closes #59