### PR TITLE
fix: libxkbcommon appimage issue

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -279,7 +279,7 @@ fn build_linux_app_image(
 
     const buffer = b.build_root.handle.readFileAlloc(
         b.graph.io,
-        "build_app_image.sh",
+        "./build/build_app_image.sh",
         allocator,
         .limited(1024 * 1024),
     ) catch unreachable;

--- a/build/build_app_image.sh
+++ b/build/build_app_image.sh
@@ -8,13 +8,14 @@ export NO_STRIP=1
 rm -rf AppDir
 rm -f zig-out/linux/spacecap-linux-x86_64.AppImage
 
-# NOTE: Vulkan is excluded because system libraries should be used.
+# NOTE: Vulkan and libxkbcommon are excluded because they should be provided by the host.
 LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}" linuxdeploy \
   --appdir AppDir \
   --executable zig-out/linux/spacecap \
   --desktop-file packaging/linux/spacecap.desktop \
   --icon-file packaging/spacecap.svg \
   --exclude-library libvulkan.so.1 \
+  --exclude-library libxkbcommon.so.0 \
   --library "$GTK3_LIB" \
   --library "$APPINDICATOR_LIB"
 

--- a/flake.nix
+++ b/flake.nix
@@ -133,13 +133,8 @@
             # Required for linux tray icon.
             pkgs.gtk3
             pkgs.libayatana-appindicator
-
-            # SDL runtime backends (don't rely on ffmpeg closure for these).
             pkgs.wayland
-            pkgs.libxkbcommon
           ];
-
-          # TODO: Separate devShell for building appimage.
         };
       }
     );

--- a/src/ui/sdl.zig
+++ b/src/ui/sdl.zig
@@ -44,7 +44,7 @@ pub fn get_sdl_vulkan_extensions(allocator: std.mem.Allocator) !SDLVulkanExtensi
     };
 }
 
-/// If Linux, try Wayland, fallback to x11.
+/// If Linux, try Wayland, fallback to x11, which causes a panic because it's not supported.
 pub fn init() !void {
     _ = imguiz.SDL_SetHint(imguiz.SDL_HINT_APP_NAME, "Spacecap");
     _ = imguiz.SDL_SetHint(imguiz.SDL_HINT_APP_ID, "spacecap");
@@ -55,8 +55,9 @@ pub fn init() !void {
             return;
         }
         if (try try_sdl_init_with_hint("x11")) {
-            log.info("[sdl_init] using x11", .{});
-            return;
+            const message = "[sdl_init] using x11, which is not supported.";
+            log.err(message, .{});
+            @panic(message);
         }
         return error.SDLInitFailure;
     }


### PR DESCRIPTION
The appimage was trying to dynamically link this library with the wrong path because it wasn't included in appimage. Exclude it so that it links to the system library.